### PR TITLE
If rootfs placed on btrfs filesystem, place root on @ subvolume

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -244,7 +244,7 @@ function prepare_partitions() {
 		display_alert "Partitioning with the following options" "$partition_script_output" "debug"
 		echo "${partition_script_output}" | run_host_command_logged sfdisk "${SDCARD}".raw || exit_with_error "Partitioning failed!"
 	fi
-	
+
 	call_extension_method "post_create_partitions" <<- 'POST_CREATE_PARTITIONS'
 		*called after all partitions are created, but not yet formatted*
 	POST_CREATE_PARTITIONS
@@ -314,9 +314,54 @@ function prepare_partitions() {
 			echo "$CRYPTROOT_MAPPER UUID=${physical_root_part_uuid} none luks" >> $SDCARD/etc/crypttab
 			run_host_command_logged cat $SDCARD/etc/crypttab
 		fi
-		
+
+		if [[ $ROOTFS_TYPE == btrfs ]]; then
+			mountopts[$ROOTFS_TYPE]='commit=120'
+			run_host_command_logged btrfs subvolume create $MOUNT/@
+			# getting the subvolume id of the newly created volume @ to install it
+			# as the default volume for mounting without explicit reference
+
+			run_host_command_logged "btrfs subvolume list $MOUNT | grep 'path @' | cut -d' ' -f2 \
+				| xargs -I{} btrfs subvolume set-default {} $MOUNT/ "
+
+			call_extension_method "btrfs_root_add_subvolumes" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES'
+				# *custom post btrfs rootfs creation hook*
+				# Called if rootfs btrfs after creating the subvolume "@" for rootfs
+				# Used to create other separate btrfs subvolume if needed.
+				# Mountpoints and fstab records should be created too.
+				run_host_command_logged btrfs subvolume create $MOUNT/@home
+				run_host_command_logged btrfs subvolume create $MOUNT/@var
+				run_host_command_logged btrfs subvolume create $MOUNT/@var_log
+				run_host_command_logged btrfs subvolume create $MOUNT/@var_cache
+				run_host_command_logged btrfs subvolume create $MOUNT/@srv
+			BTRFS_ROOT_ADD_SUBVOLUMES
+
+			run_host_command_logged umount $rootdevice
+			display_alert "Remounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"
+			run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@ $rootdevice $MOUNT/
+		fi
 		rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
-		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,noatime${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
+		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
+		if [[ $ROOTFS_TYPE == btrfs ]]; then
+			call_extension_method "btrfs_root_add_subvolumes_fstab" <<- 'BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB'
+				run_host_command_logged mkdir -p $MOUNT/home
+				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@home $rootdevice $MOUNT/home
+				echo "$rootfs / btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@home 0 1" >> $SDCARD/etc/fstab
+				run_host_command_logged mkdir -p $MOUNT/var
+				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@var $rootdevice $MOUNT/var
+				echo "$rootfs / btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@var 0 1" >> $SDCARD/etc/fstab
+				run_host_command_logged mkdir -p $MOUNT/var/log
+				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_log $rootdevice $MOUNT/var/log
+				echo "$rootfs / btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_log 0 1" >> $SDCARD/etc/fstab
+				run_host_command_logged mkdir -p $MOUNT/var/cache
+				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_cache $rootdevice $MOUNT/var/cache
+				echo "$rootfs / btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@var_cache 0 1" >> $SDCARD/etc/fstab
+				run_host_command_logged mkdir -p  $MOUNT/srv
+				run_host_command_logged mount -odefaults,${mountopts[$ROOTFS_TYPE]},subvol=@srv $rootdevice $MOUNT/srv
+				echo "$rootfs / btrfs defaults,${mountopts[$ROOTFS_TYPE]},subvol=@srv 0 1" >> $SDCARD/etc/fstab
+			BTRFS_ROOT_ADD_SUBVOLUMES_FSTAB
+		fi
+
 		run_host_command_logged cat $SDCARD/etc/fstab
 
 	else


### PR DESCRIPTION
It makes possible to work with snapshots of a root filesystem on btrfs

Using snapshots of a rootfs on btrfs needs to place root on a btrfs subvolume, not on root of btrfs volume itself.
Sometimes some of directories have to be placed on separate subvolumes.

This PR:
1. places root filesystem to "@" btrfs subvolume instead of a root of btrfs itself
2. adds 2 hook calls in fs creation process to make possible to create additional btrfs subvolumes
3. adds inactive example of usage — how to place /var, /var/log, /home directories on separate btrfs subvolumes

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

