### PR TITLE
Potential fix for code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/packages/bsp/sunxi-temp/mod_mmio.h
+++ b/packages/bsp/sunxi-temp/mod_mmio.h
@@ -76,7 +76,7 @@ static void mmio_normalize(struct mmio *mo)
 
 	npages += (mo->range * sizeof(uint32_t)) / getpagesize();
 	npages += 1;
-	mo->iosize = npages * getpagesize();
+	mo->iosize = (size_t)npages * (size_t)getpagesize();
 }
 
 static void mmio_init(struct mmio *mo)


### PR DESCRIPTION
Potential fix for [https://github.com/iav/armbian/security/code-scanning/8](https://github.com/iav/armbian/security/code-scanning/8)

Use wider-type arithmetic for the multiplication so overflow cannot happen in `int` before assignment to `size_t`.

Best fix in this snippet: in `mmio_normalize` (around line 79), cast one operand to `size_t` before multiplying:
- Change `mo->iosize = npages * getpagesize();`
- To `mo->iosize = (size_t)npages * (size_t)getpagesize();`

This ensures the multiplication is performed in `size_t` and the result is safely stored in `mo->iosize` without intermediate `int` overflow. No new headers or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
