### PR TITLE
test: reviewdog/action-shellcheck inline annotations demo

### DIFF
--- a/.github/demo-reviewdog-shellcheck.sh
+++ b/.github/demo-reviewdog-shellcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Demo file for reviewdog/action-shellcheck PR-review test.
+# Intentionally broken — do not source or execute.
+#
+# Mix of severities so the level=error / fail_level=error gate can be
+# observed: only the SC1xxx parser error below should turn into a PR
+# review-comment when the new maintenance-lint-scripts-reviewdog.yml
+# workflow runs.
+
+# SC2086 — unquoted variable expansion (info)
+arg=$1
+echo $arg
+
+# SC2034 — assigned but never used (warning)
+unused="dead"
+
+# SC2046 — quote $() to prevent word splitting (warning)
+ls $(echo /tmp)
+
+# SC1073 — parser error: unmatched $( (error)
+broken=$(echo hello


### PR DESCRIPTION
Fork-internal demo PR. Do not merge.

Exercises the new `maintenance-lint-scripts-reviewdog.yml` workflow added on the `audit/shellcheck-comparison` branch. The added `.github/demo-reviewdog-shellcheck.sh` contains an `SC1073`/`SC1072` parser-error pair which `reviewdog/action-shellcheck` should surface as inline review-comments on this PR's diff.

Expected:
- `Shell script analysis (reviewdog)` check appears in the PR status list
- 2 inline review comments on lines 21–22 of `.github/demo-reviewdog-shellcheck.sh`
- Workflow exits non-zero due to `fail_level: error`