### PR TITLE
fix(armbian-leds): strip brightness only for :link / phy*tpt triggers

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-led-state-save.sh
+++ b/packages/bsp/common/usr/lib/armbian/armbian-led-state-save.sh
@@ -24,7 +24,7 @@ function store_led() {
 	TRIGGER_PATH="$1/trigger"
 	DESTINATION="$2"
 
-	TRIGGER_CONTENT=$(<$TRIGGER_PATH)
+	TRIGGER_CONTENT=$(< $TRIGGER_PATH)
 
 	[[ "$TRIGGER_CONTENT" =~ $REGEX ]]
 
@@ -40,15 +40,48 @@ function store_led() {
 	COMMAND_PARAMS="$CMD_FIND $PATH/ -maxdepth 1 -type f ! -iname uevent ! -iname trigger -perm /u+w -printf %f\\n"
 	PARAMS=$($COMMAND_PARAMS)
 
-	# In case trigger is representing link-state for any network, use
-	# bash substitution to remove the brightness parameter and avoid
-	# ghost wan/lan/etc (led up while cable unplugged)
-	[[ "$TRIGGER_VALUE" == *":link" ]] && PARAMS=${PARAMS//"brightness"/}
+	# brightness semantics depend on the trigger:
+	#   trigger=none           → brightness is plain config (static value).
+	#   trigger=netdev/pattern → brightness is a "ceiling" the trigger may
+	#                            scale to (kernel LED ABI: writing non-zero
+	#                            brightness while a trigger is active sets
+	#                            the top brightness for the trigger's
+	#                            output). Board configs use this on purpose
+	#                            (e.g. radxa-e52c.conf has brightness=1
+	#                            under trigger=netdev to dim the blink).
+	#   noisy triggers below   → brightness is the trigger's instantaneous
+	#                            output (link-up/down boolean, tpt blink
+	#                            state). Capturing it on shutdown produces
+	#                            ghost-LED bugs on restore (":link" showed
+	#                            cable-up while unplugged) and constant
+	#                            churn in /etc/armbian-leds.conf (rtw88
+	#                            phy0tpt flapped 0/1 every shutdown).
+	# Strip brightness only for the noisy set; keep it for everything else
+	# so legitimate dim ceilings survive the save/restore cycle.
+	# Pattern history: ":link"-only strip was the original workaround in
+	# commit 2960ffaff; "phy*tpt" extends it to the rtw88 forum case.
+	# Forum thread: https://forum.armbian.com/topic/57284-regular-changes-in-file-etcarmbian-ledsconf-on-odroid-n2/
+	#
+	# Token-safe whole-word filter: the simpler ${PARAMS//brightness/}
+	# substring substitution would also corrupt sibling files like
+	# `max_brightness` → `max_`, breaking the read loop below under set -e.
+	# Bash-only (no `awk` etc.) because store_led() reassigns PATH to the
+	# sysfs led path, so external commands aren't on PATH here.
+	case "$TRIGGER_VALUE" in
+		*:link | phy*tpt)
+			declare _filtered=""
+			for _p in $PARAMS; do
+				[[ "$_p" == "brightness" ]] && continue
+				_filtered+="$_p"$'\n'
+			done
+			PARAMS="$_filtered"
+			;;
+	esac
 
 	for PARAM in $PARAMS; do
 
 		PARAM_PATH="$PATH/$PARAM"
-		VALUE=$(<$PARAM_PATH)
+		VALUE=$(< $PARAM_PATH)
 
 		# If the variable contains non-printable characters
 		# suppose it contains binary and skip it

--- a/packages/bsp/common/usr/lib/armbian/armbian-led-state-save.sh
+++ b/packages/bsp/common/usr/lib/armbian/armbian-led-state-save.sh
@@ -34,8 +34,15 @@ function store_led() {
 	echo "trigger=$TRIGGER_VALUE" >> $DESTINATION
 
 	# In case the trigger is any of the kbd-*, don't store any other parameter
-	# This avoids num/scroll/capslock from being restored at startup
-	[[ "$TRIGGER_VALUE" =~ kbd-* ]] && return
+	# This avoids num/scroll/capslock from being restored at startup.
+	# Use shell glob (anchored at start of string) rather than bash regex —
+	# `=~ kbd-*` is regex where `*` is "0+ of preceding `-`" and the match
+	# is not anchored, so any trigger containing `kbd` could match. The
+	# `case kbd-*)` form is anchored and matches only triggers that
+	# literally start with `kbd-`.
+	case "$TRIGGER_VALUE" in
+		kbd-*) return ;;
+	esac
 
 	COMMAND_PARAMS="$CMD_FIND $PATH/ -maxdepth 1 -type f ! -iname uevent ! -iname trigger -perm /u+w -printf %f\\n"
 	PARAMS=$($COMMAND_PARAMS)


### PR DESCRIPTION
## Summary

`armbian-led-state-save.sh` saves LED state on shutdown for restore at boot.
For two narrow trigger families, `brightness` from sysfs is **not config**
but the trigger's instantaneous output (link-up/down boolean, tpt blink
state). Capturing it on shutdown and replaying it at boot produces:

- Ghost-LED bugs on restore — `:link` triggers showed cable-up while
  unplugged after restoring a saved `brightness=1` (PR #7337's case)
- Constant churn in `/etc/armbian-leds.conf` on every shutdown — visible
  to anyone with `etckeeper` / etc-diff alerts (rtw88 `phy0tpt` flapped
  0/1; the forum-thread case)

**Fix:** strip `brightness` only for the noisy set:

```bash
case "$TRIGGER_VALUE" in
    *:link | phy*tpt) ... ;;
esac
```

Everything else keeps `brightness` as legitimate config — including the
kernel LED ABI "ceiling" semantics (writing non-zero brightness while a
trigger is active sets the top brightness for the trigger's output),
which `config/boards/radxa-e52c.conf` and `radxa-e54c.conf` rely on with
`brightness=1` under `trigger=netdev` for a dimmed link blink.

The token-safe whole-word filter (instead of `${PARAMS//brightness/}`
substring substitution) is required either way to avoid corrupting
sibling files like `max_brightness` → `max_`.

## History

Pattern grew incrementally from existing point-fixes for the same root cause:

- `:link`-only strip in PR #7337 (commit `2960ffaff`) — original ghost-LED case
- `phy*tpt` extension here — covers the rtw88 forum-thread case
- Restore-side `[[ $VALUE -eq 0 ]] && continue` guard in
  `armbian-led-state-restore.sh` — independent guard against writing 0
  (which would kick trigger back to `none`); kept untouched

A previous version of this PR (commit `56a978bd4`) blanket-stripped
brightness for any non-`none` trigger, but that regressed legitimate dim
ceilings (radxa-e52c case above). Narrowed to the explicit blacklist on
review feedback.

## Forum reference

Documented in detail (with diff samples and root-cause analysis by
@tparys) on the Armbian forum:
[Regular changes in file /etc/armbian-leds.conf on ODroid-N2](https://forum.armbian.com/topic/57284-regular-changes-in-file-etcarmbian-ledsconf-on-odroid-n2/)

## Test plan

Standalone scaffold (`.tmp/test-led-state-save.sh`) mocks
`/sys/class/leds/` and runs the save script:

- [x] `trigger=eth0:link`, saved `brightness=1` → `brightness` stripped
- [x] `trigger=phy0tpt`, saved `brightness=0` → `brightness` stripped
- [x] `trigger=netdev`, saved `brightness=1` (radxa dim case) → **preserved**
- [x] `trigger=heartbeat`, saved `brightness=42` → preserved
- [x] `trigger=disk-activity`, saved `brightness=255` → preserved
- [x] `trigger=none`, saved `brightness=128` → preserved
- [x] Other writable knobs (`delay_on=100`, `link=1`, `tx=0`, `rx=1`)
      preserved on every LED
- [x] `max_brightness` not corrupted by token-safe filter (was
      `${PARAMS//brightness/}` → `max_` substring bug)
