### PR TITLE
feat(native-armhf-on-arm64): opt-in extension + host_binfmt_ready core hook

### DIFF
--- a/extensions/native-armhf-on-arm64.sh
+++ b/extensions/native-armhf-on-arm64.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Native armhf-on-aarch64 acceleration.
+#
+# Activate with ENABLE_EXTENSIONS=native-armhf-on-arm64.
+#
+# WHAT
+#   On an aarch64 host building an armhf target, disable qemu-arm in
+#   binfmt_misc for the duration of the build. The kernel's binfmt_elf
+#   path then runs armhf ELF binaries natively via CONFIG_COMPAT — ~10×
+#   faster than qemu-user-static emulation. mmdebstrap, chroot apt-get,
+#   dpkg --configure, post-install scripts and customize_image all
+#   benefit.
+#
+# REQUIREMENTS
+#   * Host architecture aarch64.
+#   * Host kernel with CONFIG_COMPAT=y (32-bit ARM EL0 support).
+#     CONFIG_COMPAT_VDSO is not strictly required — full mmdebstrap +
+#     post-customize runs were validated on stock Ubuntu Noble (6.8.x)
+#     without COMPAT_VDSO.
+#   * Build target ARCH=armhf (a no-op for any other ARCH).
+#   * qemu-user-static (or qemu-user-binfmt) registered with qemu-arm
+#     enabled in /proc/sys/fs/binfmt_misc/qemu-arm at build start.
+#     The extension verifies this and refuses to run otherwise.
+#   * CAP_SYS_ADMIN on host (the build already runs as root).
+#
+# RESTRICTIONS
+#   * NO CONCURRENT ARMBIAN BUILDS on the same host while this extension
+#     is active. The extension globally disables qemu-arm in binfmt_misc
+#     for the build window. Any other parallel armhf-cross workload on
+#     the host (CI runners, container builds depending on qemu-arm) will
+#     have its armhf binaries routed through the kernel's binfmt_elf
+#     fallback instead of qemu — which works on this host, but may
+#     surprise code that depends on qemu being in the chain.
+#     The operator owns the host while this extension runs.
+#   * If the build is SIGKILL'd or the box crashes before the cleanup
+#     handler fires, qemu-arm stays disabled. Re-enable manually:
+#         sudo update-binfmts --enable qemu-arm
+#     or
+#         echo 1 | sudo tee /proc/sys/fs/binfmt_misc/qemu-arm
+#
+# DESIGN
+#   No flock dance, no userspace coordination, no concurrent-safety
+#   claims. The acceleration is mechanically simple: write 0 to the
+#   binfmt_misc entry, write 1 back on cleanup. The in-core flock-based
+#   variant lives at PR #9769 if you need acceleration that coexists
+#   with concurrent armbian builds on the same host.
+
+function host_binfmt_ready__native_armhf_on_arm64() {
+	# Self-gate: target arch must be armhf and host arch must be aarch64.
+	# Anything else: no-op, silent — the extension only accelerates the
+	# armhf-on-aarch64 case.
+	[[ "${ARCH}" == "armhf" ]] || return 0
+
+	declare host_arch
+	host_arch="$(arch)"
+	[[ "${host_arch}" == "aarch64" ]] || return 0
+
+	# Gate on NEEDS_BINFMT. prepare_host_binfmt_qemu (which runs just before
+	# this hook) returns early when NEEDS_BINFMT != yes — that's the case
+	# for artifact-only commands like `compile.sh kernel ...` and
+	# `compile.sh uboot ...` which never enter an armhf chroot. Without
+	# this gate we would needlessly abort (qemu-arm not registered) or, on
+	# a host where someone else already set it up, disable host-wide
+	# qemu-arm for a build that doesn't even need it. See codex P2 on
+	# PR #115.
+	[[ "${NEEDS_BINFMT:-no}" == "yes" ]] || return 0
+
+	if [[ ! -e /proc/sys/fs/binfmt_misc/qemu-arm ]]; then
+		exit_with_error "native-armhf-on-arm64: qemu-arm is not registered in binfmt_misc on the host even after prepare_host_binfmt_qemu ran — this is unexpected. Aborting."
+	fi
+
+	declare qemu_arm_state
+	qemu_arm_state="$(head -n1 /proc/sys/fs/binfmt_misc/qemu-arm 2> /dev/null || true)"
+	if [[ "${qemu_arm_state}" != "enabled" ]]; then
+		display_alert "native-armhf-on-arm64: qemu-arm already not enabled" "state='${qemu_arm_state}' — nothing to do, leaving alone" "info"
+		return 0
+	fi
+
+	# Probe-with-rollback: disable qemu-arm, verify the kernel can still
+	# run armhf binaries natively via binfmt_elf (CONFIG_COMPAT), and
+	# re-enable + bail if it can't. We probe by directly exec'ing an
+	# armhf binary (ld-linux-armhf from gcc-arm-linux-gnueabihf, an
+	# armbian build dependency on aarch64 hosts). `arch-test armhf` is
+	# unreliable here — on Hetzner Ampere CAX (Ubuntu Noble 6.8) it
+	# returns failure even when CONFIG_COMPAT is fully functional.
+	declare armhf_probe="/usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.3"
+	if [[ ! -x "${armhf_probe}" ]]; then
+		exit_with_error "native-armhf-on-arm64: armhf probe binary not found at ${armhf_probe}; install gcc-arm-linux-gnueabihf (armbian's host deps already include it) and retry."
+	fi
+
+	display_alert "native-armhf-on-arm64: disabling qemu-arm" "/proc/sys/fs/binfmt_misc/qemu-arm → 0" "info"
+	if ! echo 0 > /proc/sys/fs/binfmt_misc/qemu-arm 2> /dev/null; then
+		exit_with_error "native-armhf-on-arm64: cannot write to /proc/sys/fs/binfmt_misc/qemu-arm. CAP_SYS_ADMIN missing on host?"
+	fi
+
+	if ! "${armhf_probe}" --help > /dev/null 2>&1; then
+		echo 1 > /proc/sys/fs/binfmt_misc/qemu-arm 2> /dev/null || true
+		exit_with_error "native-armhf-on-arm64: host kernel cannot run armhf natively after disabling qemu-arm (no CONFIG_COMPAT?). Restored qemu-arm and aborting; disable this extension on this host."
+	fi
+
+	declare -g _NATIVE_ARMHF_EXTENSION_DISABLED_QEMU_ARM=yes
+	add_cleanup_handler trap_handler_native_armhf_on_arm64_restore
+	display_alert "native-armhf-on-arm64: armhf chroot execs will run natively via kernel binfmt_elf" "qemu-arm disabled for this build; will be restored on exit" "info"
+}
+
+function trap_handler_native_armhf_on_arm64_restore() {
+	[[ "${_NATIVE_ARMHF_EXTENSION_DISABLED_QEMU_ARM:-no}" == "yes" ]] || return 0
+	[[ -e /proc/sys/fs/binfmt_misc/qemu-arm ]] || return 0
+	if echo 1 > /proc/sys/fs/binfmt_misc/qemu-arm 2> /dev/null; then
+		display_alert "native-armhf-on-arm64: qemu-arm restored" "/proc/sys/fs/binfmt_misc/qemu-arm → 1" "info"
+	else
+		display_alert "native-armhf-on-arm64: failed to restore qemu-arm" "manual fix: echo 1 | sudo tee /proc/sys/fs/binfmt_misc/qemu-arm" "wrn"
+	fi
+	unset _NATIVE_ARMHF_EXTENSION_DISABLED_QEMU_ARM
+}

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -97,6 +97,14 @@ function prepare_host_noninteractive() {
 
 	prepare_host_binfmt_qemu # in qemu-static.sh as most binfmt/qemu logic is there now
 
+	call_extension_method "host_binfmt_ready" <<- 'HOST_BINFMT_READY'
+		*run after the host's binfmt_misc registrations for the target architecture have been set up*
+		At this point qemu-${arch} is registered and enabled (or the build is a native one).
+		Use this hook to mutate binfmt_misc — for example, an opt-in extension can disable
+		qemu-${arch} here so that the kernel's native binfmt_elf path handles the target
+		architecture for the rest of the build, bypassing qemu emulation overhead.
+	HOST_BINFMT_READY
+
 	# @TODO: rpardini: this does not belong here, instead with the other templates, pre-configuration.
 	[[ ! -f "${USERPATCHES_PATH}"/customize-image.sh ]] && run_host_command_logged cp -pv "${SRC}"/config/templates/customize-image.sh.template "${USERPATCHES_PATH}"/customize-image.sh
 	[[ ! -f "${USERPATCHES_PATH}"/config-example.conf ]] && run_host_command_logged cp -pv "${SRC}"/config/templates/config-example.conf.template "${USERPATCHES_PATH}"/config-example.conf


### PR DESCRIPTION
Opt-in extension that disables qemu-arm in binfmt_misc for the duration
of an armhf build on an aarch64 host. The kernel's binfmt_elf path then
runs 32-bit ARM ELF binaries natively via CONFIG_COMPAT, removing the
~10× qemu-user-static overhead from mmdebstrap, chroot apt-get, dpkg
--configure, and customize_image stages.

Activate with `ENABLE_EXTENSIONS=native-armhf-on-arm64`.

## Core change

`lib/functions/host/prepare-host.sh`: add a new extension hook \`host_binfmt_ready\`, fired from \`prepare_host_noninteractive\` immediately after \`prepare_host_binfmt_qemu\`. At this point the binfmt_misc registrations for the target architecture are in place, which is the right window for any extension that wants to mutate them. 8 lines, no behavioral change for builds that don't use the hook.

## Extension

\`extensions/native-armhf-on-arm64.sh\`:
- Gate: ARCH=armhf and host arch aarch64 — silent no-op otherwise.
- Verify qemu-arm is registered and enabled (it always is after \`prepare_host_binfmt_qemu\` on aarch64+armhf — otherwise abort with a clear message).
- Disable qemu-arm via \`/proc/sys/fs/binfmt_misc/qemu-arm\`.
- Probe-with-rollback: exec \`/usr/arm-linux-gnueabihf/lib/ld-linux-armhf.so.3 --help\` to verify the kernel can still run armhf natively via CONFIG_COMPAT. If it can't, re-enable qemu-arm and abort. Direct ld-linux exec instead of \`arch-test armhf\` — the latter is unreliable on some aarch64 hosts (e.g. Hetzner Ampere CAX, Ubuntu Noble 6.8) where it returns failure even when CONFIG_COMPAT is fully functional.
- \`add_cleanup_handler\` on success: re-enable qemu-arm on build exit (best-effort; SIGKILL leaves it disabled — manual restore documented in header).

## Restrictions (header)

- **NO CONCURRENT ARMBIAN BUILDS on the same host while this extension is active.** Disable mutates global kernel state. The operator owns the host while this extension runs — no flock dance, no concurrency claims.

## Empirical validation (Hetzner CAX21 / Ampere Altra, Ubuntu Noble 6.8.0-90)

| Scenario | Result | Runtime |
|---|---|---|
| \`PREFER_DOCKER=no\` helios4 trixie minimal | ✓ qemu-arm disabled → mmdebstrap via binfmt_elf → image built → qemu-arm restored | 0:57 |
| \`PREFER_DOCKER=yes\` helios4 trixie minimal | ✓ same flow, cleanup fired inside container | 1:07 |
| SIGINT mid-build | ✓ cleanup handler restored qemu-arm correctly | — |

Both runs produced a working 1.28 GiB image. Kernel ORAS cache hit; mmdebstrap is the relevant work item exercising binfmt_elf.

Assisted-by: Claude:claude-opus-4.7