### PR TITLE
fix(deps): add Pygments to requirements.txt (rich.syntax dep)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ PyYAML == 6.0.3        # for parsing/writing YAML
 oras == 0.2.42         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.6        # for templating
 rich == 15.0.0         # for rich text formatting
+Pygments == 2.19.1     # syntax highlighting, required by rich.syntax (imported by lib/tools/patching.py)
 dtschema == 2026.4     # for checking dts files and dt bindings
 yamllint == 1.38.0     # for checking dts files and dt bindings


### PR DESCRIPTION
`lib/tools/patching.py:444` imports `from rich.syntax import Syntax`. The `rich` package already pinned in `requirements.txt` does not pull `Pygments` as a hard runtime dependency — it is an `extras_require` for syntax highlighting. On a fresh host where `requirements.txt` is the only source of pip installs, the build fails:

```
Traceback (most recent call last):
  File "/armbian/lib/tools/patching.py", line 444, in <module>
    from rich.syntax import Syntax
  File ".../rich/syntax.py", line 24, in <module>
    from pygments.lexer import Lexer
ModuleNotFoundError: No module named 'pygments'
```

Reproduced on a fresh Hetzner CAX21 (Ubuntu Noble 6.8) with:

```
./compile.sh build BOARD=helios4 BRANCH=edge BUILD_MINIMAL=yes \
  RELEASE=noble PREFER_DOCKER=yes KERNEL_CONFIGURE=no EXPERT=yes \
  ARTIFACT_IGNORE_CACHE=yes
```

Fail surface is the u-boot patching phase (`uboot_main_patching_python`); any code path that imports `rich.syntax` is affected.

Pin `Pygments == 2.19.1` so dependabot can keep it current alongside `rich`.

Assisted-by: Claude:claude-opus-4.7