### PR TITLE
kernel: run `kernel_copy_extra_sources` hooks after `kernel_maybe_clean`

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -41,13 +41,13 @@ function compile_kernel() {
 	kernel_base_revision_date="$(LC_ALL=C date -d "@${kernel_base_revision_ts}")"
 	display_alert "Using Kernel git revision" "${kernel_git_revision} at '${kernel_base_revision_date}'"
 
+	# Possibly 'make clean'.
+	LOG_SECTION="kernel_maybe_clean" do_with_logging do_with_hooks kernel_maybe_clean
+
 	# Call extension method to prepare extra sources
 	call_extension_method "kernel_copy_extra_sources" <<- 'ARMBIAN_KERNEL_SOURCES_EXTRA'
 		*Hook to copy extra kernel sources to the kernel under compilation*
 	ARMBIAN_KERNEL_SOURCES_EXTRA
-
-	# Possibly 'make clean'.
-	LOG_SECTION="kernel_maybe_clean" do_with_logging do_with_hooks kernel_maybe_clean
 
 	# Patching.
 	declare hash pre_patch_version


### PR DESCRIPTION
Codex review trap for upstream armbian/build#9830 by @rpardini.

## What

Two-line swap in `lib/functions/compilation/kernel.sh`: move
`LOG_SECTION="kernel_maybe_clean" do_with_logging do_with_hooks kernel_maybe_clean`
to run *before* `call_extension_method "kernel_copy_extra_sources"`.

## Why it matters

`kernel_maybe_clean` does `git clean -xfdq` on the kernel work tree when
`CLEAN_LEVEL` contains `make-kernel`. With the previous ordering, any
files copied into the kernel tree by extensions/board code via the
`kernel_copy_extra_sources` hook were immediately wiped, forcing
contributors to copy from unrelated hooks together with the
`CONFIG_DEFS_ONLY=yes` workaround — which in turn causes the kernel
artifact `-HK` hash to diverge from the actual build, poisoning the
artifact cache.

After this PR `kernel_copy_extra_sources` actually does what its name
says, and contributors can drop the workarounds. Cache-correctness is
preserved iff the hook author folds the source SHA1 of whatever is
being copied into the hash material — explicitly called out in the
upstream commit message.

## Upstream

https://github.com/armbian/build/pull/9830

Fixes upstream commit c47c9372bf6970d6ca8c32bc5f7ec2a1416ab5bd
("Add new hook to allow copying code into kernel").

## Asking codex

Please verify:
1. Is the new ordering correct given the rest of the kernel pipeline
   (`kernel_main_patching`, `kernel_prepare_build_and_package`)?
2. Are there existing call sites in `extensions/` or board code that
   *depend* on the old (broken) ordering?
3. Is the responsibility to fold the copied source hash into the
   artifact hash sufficiently captured today, or does this PR need
   a companion hardening change?