### PR TITLE
demo: ShellCheck/shfmt PR-comment examples

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -51,3 +51,28 @@ cli_entrypoint "$@"
 
 # Log the last statement of this script for debugging purposes.
 display_alert "Armbian build script exiting" "very last thing" "cleanup"
+
+# TEST: shellcheck demo block — NOT called, only here so the new
+# maintenance-shellcheck-suggest workflow has something to flag in PR.
+# - SC2006 / SC2196: shellcheck can auto-fix these → reviewdog/action-suggester
+#   posts them as inline `suggestion` blocks.
+# - SC2154 / SC2164: shellcheck cannot auto-fix these → reviewdog posts as
+#   inline review comments without a click-to-apply suggestion.
+# Remove this block once the workflow is verified end-to-end.
+function _shellcheck_demo() {
+	# SC2006: legacy `cmd` backticks — autofix to $()
+	local kernel=`uname -r`
+
+	# SC2196: egrep is deprecated — autofix to `grep -E`
+	echo "$kernel" | egrep '^[0-9]'
+
+	# SC2154: referenced but never assigned — no autofix, review comment only.
+	echo "$undefined_var_for_demo"
+
+	# SC2164: cd may fail and the script keeps going — no autofix.
+	cd /tmp
+
+	# Note: double space + redirect with no surrounding space — only
+	# shfmt complains; shellcheck doesn't flag this.
+	echo "demo"  "value">/dev/null
+}


### PR DESCRIPTION
Demo PR showcasing all four output channels of the new `Maintenance: Lint scripts` + `Maintenance: Lint scripts (post)` two-phase pipeline (proposed for upstream `armbian/build`).

The single commit adds a never-called `_shellcheck_demo()` function at the bottom of `compile.sh` with four intentional issues. The pipeline reacts to each as follows:

| Line | Code | Path |
|---|---|---|
| 64 | SC2006 (legacy backticks) | `shellcheck -f diff` produces an auto-fix → posted as inline **`suggestion` block** (click to apply) |
| 64 | SC2155 (declare-and-assign masks return) | No auto-fix → posted as plain **inline review comment** |
| 70 | SC2154 (referenced but not assigned) | No auto-fix → posted as plain **inline review comment** |
| 77 | shfmt drift (double space + redirect spacing) | `shfmt -d` produces a diff → posted as **`suggestion` block** |

Plus the lint phase also gives a red-cross Check on the PR (because some findings are critical), as the previous single-phase `maintenance-lint-scripts.yml` did.

Architecture notes:
- **Two-phase pipeline** because GitHub gives a read-only `GITHUB_TOKEN` to PRs originating from forks. Phase 1 (lint) runs in PR context with read-only token, produces artifacts. Phase 2 (post) is `on: workflow_run`, runs in base context with full write token, downloads artifacts and posts via `reviewdog`. PR code is never executed in the privileged context — CodeQL's `actions/untrusted-checkout` rule stays quiet.
- Workflows live on the `ci-base` branch (default in this fork) so `main` remains a clean mirror of `armbian/build:main` and can be rebased onto upstream without conflict.

Demo intended only for showcasing PR-comment output — not for merging. The actual upstream PR will not include this demo commit.

Assisted-by: Claude:claude-opus-4.7