### PR TITLE
ci: post ShellCheck findings and auto-fix suggestions inline on PRs

### DIFF
--- a/.github/workflows/maintenance-lint-scripts-post.yml
+++ b/.github/workflows/maintenance-lint-scripts-post.yml
@@ -1,0 +1,189 @@
+name: "Maintenance: Lint scripts (post)"
+#
+# Second phase of the two-phase lint pipeline. Triggered by the
+# completion of maintenance-lint-scripts.yml ("Maintenance: Lint
+# scripts"), runs in the BASE repository's context with a full write
+# token — so review comments and suggestion blocks can be posted to
+# pull requests originating from forks too.
+#
+# Security boundary: this workflow never checks out PR code. It only
+# downloads the lint job's artifacts (text findings + unified diffs +
+# PR metadata) and feeds them to reviewdog. CodeQL's
+# actions/untrusted-checkout rule stays quiet because no
+# `actions/checkout` runs with `ref: ${{ github.event.pull_request.head.sha }}`
+# (or equivalent untrusted ref).
+#
+# Note: GitHub always runs `workflow_run` workflows from the default
+# branch's copy of this file, so changes to the post pipeline take
+# effect only after merging into the default branch.
+#
+# Runs on every fork of armbian/build by default. If a fork doesn't
+# want PR comments — disable Settings → Actions → Workflows →
+# "Maintenance: Lint scripts (post)". Disabling only the post leaves
+# the red-cross Check still working (Maintenance: Lint scripts itself);
+# disabling both leaves the fork lint-free.
+
+on:
+  workflow_run:
+    workflows: ["Maintenance: Lint scripts"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  issues: write    # documented requirement of reviewdog for PR-comment APIs
+
+jobs:
+  Post:
+    name: Post ShellCheck and shfmt diagnostics
+    runs-on: ubuntu-latest
+    # Run even on red-cross lint conclusions — the artifact is uploaded
+    # via `if: always()` in the lint workflow, and we want to surface
+    # diagnostics in the PR even if the gate failed. Only skip on the
+    # rare cases where there is no artifact (cancelled/timed-out runs).
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    steps:
+      - name: Checkout BASE for reviewdog's local git context
+        # reviewdog requires a `.git` to be present even when its
+        # reporter (`github-pr-review`) computes the PR diff via API.
+        # Checking out BASE (the workflow's default branch — our own
+        # trusted code) gives it what it needs without ever pulling PR
+        # code into the privileged context; CodeQL's untrusted-checkout
+        # rule stays quiet because there is no `ref: ...head.sha`.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false   # defense-in-depth: post-step uses REVIEWDOG_GITHUB_API_TOKEN, not the on-disk extraheader
+
+      - name: Surface workflow purpose + disable instructions in the Check summary
+        run: |
+          cat >>"$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## What this Check does
+
+          `Maintenance: Lint scripts (post)` is the second phase of the lint pipeline. It downloads diagnostic artifacts produced by `Maintenance: Lint scripts` and posts them as inline review comments and auto-fix `suggestion` blocks on the PR via [reviewdog](https://github.com/reviewdog/reviewdog).
+
+          ### Don't want PR comments?
+
+          This workflow runs on every fork of `armbian/build` by default. To stop the PR-comment spam:
+
+          * **Just the comments** — Settings → Actions → Workflows → "Maintenance: Lint scripts (post)" → "Disable workflow". The lint Check itself (red cross / green check) keeps working.
+          * **Disable both phases** — disable `Maintenance: Lint scripts` instead; the post phase becomes a no-op automatically because there are no artifacts.
+
+          EOF
+
+      - name: Download lint artifacts (no checkout of PR code)
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: lint-scripts-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Synthesize pull_request event JSON for reviewdog
+        run: |
+          # reviewdog in a workflow_run context cannot find PR info on
+          # its own — GITHUB_EVENT_NAME is `workflow_run` and
+          # GITHUB_EVENT_PATH points to a workflow_run payload, not a
+          # pull_request event. CI_* fallback env vars are bypassed when
+          # GitHub Actions context is detected. Workaround: synthesize a
+          # minimal pull_request event JSON, then override
+          # GITHUB_EVENT_NAME and GITHUB_EVENT_PATH at the step level
+          # for each subsequent reviewdog invocation.
+          PR_NUMBER=$(cat pr-number.txt)
+          HEAD_SHA=$(cat head-sha.txt)
+          BASE_SHA=$(cat base-sha.txt)
+          BASE_REF=$(cat base-ref.txt)
+          BASE_REPO=$(cat base-repo.txt)
+          OWNER="${BASE_REPO%/*}"
+          NAME="${BASE_REPO##*/}"
+          jq -n \
+            --argjson number "$PR_NUMBER" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg base_sha "$BASE_SHA" \
+            --arg base_ref "$BASE_REF" \
+            --arg owner "$OWNER" \
+            --arg name "$NAME" \
+            --arg full "$BASE_REPO" \
+            '{
+              "action": "synchronize",
+              "number": $number,
+              "repository": {
+                "name": $name,
+                "full_name": $full,
+                "owner": { "login": $owner }
+              },
+              "pull_request": {
+                "number": $number,
+                "head": {
+                  "sha": $head_sha,
+                  "ref": "pr-head",
+                  "repo": { "full_name": $full, "name": $name, "owner": { "login": $owner } }
+                },
+                "base": {
+                  "sha": $base_sha,
+                  "ref": $base_ref,
+                  "repo": { "full_name": $full, "name": $name, "owner": { "login": $owner } }
+                }
+              }
+            }' > /tmp/pr-event.json
+          cat /tmp/pr-event.json
+          echo "FAKE_PR_EVENT_PATH=/tmp/pr-event.json" >> "$GITHUB_ENV"
+
+      - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.4.0
+        with:
+          reviewdog_version: latest
+
+      # GitHub Actions strips `GITHUB_*` overrides from step-level
+      # `env:` blocks (documented), so we apply the overrides inline as
+      # bash command-environment variables — GitHub can't touch those.
+      - name: Post ShellCheck findings as inline review comments
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # reviewdog has no built-in `gcc` parser; supply vim
+          # errorformat (-efm) patterns matching
+          # `file:line:col: severity: message`. Three patterns cover
+          # error / warning / note outputs.
+          cat shellcheck-findings.txt | env \
+            GITHUB_EVENT_NAME=pull_request \
+            GITHUB_EVENT_PATH="$FAKE_PR_EVENT_PATH" \
+            reviewdog \
+              -name=shellcheck-findings \
+              -efm='%f:%l:%c: %trror: %m' \
+              -efm='%f:%l:%c: %tarning: %m' \
+              -efm='%f:%l:%c: %tote: %m' \
+              -reporter=github-pr-review \
+              -filter-mode=added \
+              -fail-level=none
+
+      - name: Post ShellCheck auto-fix as suggestion blocks
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # `-f=diff` parses unified-diff input and emits `suggestion`
+          # blocks for each hunk on PR-added lines (filter_mode=added).
+          # Replaces reviewdog/action-suggester (which needs a checked-
+          # out worktree to compute the diff itself).
+          cat shellcheck-fix.diff | env \
+            GITHUB_EVENT_NAME=pull_request \
+            GITHUB_EVENT_PATH="$FAKE_PR_EVENT_PATH" \
+            reviewdog \
+              -name=shellcheck-fix \
+              -f=diff \
+              -filter-mode=added \
+              -reporter=github-pr-review \
+              -fail-level=none
+
+      - name: Post shfmt drift as suggestion blocks
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat shfmt.diff | env \
+            GITHUB_EVENT_NAME=pull_request \
+            GITHUB_EVENT_PATH="$FAKE_PR_EVENT_PATH" \
+            reviewdog \
+              -name=shfmt \
+              -f=diff \
+              -filter-mode=added \
+              -reporter=github-pr-review \
+              -fail-level=none

--- a/.github/workflows/maintenance-lint-scripts.yml
+++ b/.github/workflows/maintenance-lint-scripts.yml
@@ -1,11 +1,25 @@
 name: "Maintenance: Lint scripts"
 run-name: 'Shellcheck - PR #${{ github.event.pull_request.number }} ("${{ github.event.pull_request.title }}")'
 #
-# Run ShellCheck on all scripts and generate report as build artifact
+# Lint phase of a two-phase pipeline that produces both:
+#   * a pass/fail Check on the PR (red cross on critical findings); and
+#   * artifacts consumed by maintenance-lint-scripts-post.yml, which
+#     posts findings and auto-fix suggestions inline on the PR via
+#     reviewdog.
 #
+# The post workflow runs via `workflow_run` in the base repository
+# context with a write token, so PR comments work for forks too.
+# This workflow itself only needs a read token.
+#
+# Runs on every fork of armbian/build by default. If a fork doesn't
+# want it (private fork, repurposed tree, etc.), disable either:
+#   * the whole Actions surface — Settings → Actions → General →
+#     "Disable actions"; or
+#   * just this workflow — Settings → Actions → General →
+#     "Allow ... and select non-Armbian actions" + explicitly disable
+#     "Maintenance: Lint scripts" under Actions → Workflows.
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -13,16 +27,34 @@ permissions:
   contents: read
 
 concurrency:
-  group: pipeline-lint-${{github.event.pull_request.number}}
+  group: pipeline-lint-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   Shellcheck:
     name: Shell script analysis
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'Armbian' }}
 
     steps:
+      - name: Surface workflow purpose + disable instructions in the Check summary
+        run: |
+          cat >>"$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## What this Check does
+
+          `Maintenance: Lint scripts` runs ShellCheck on the PR's shell scripts and produces:
+
+          * a **red cross / green check** on the PR (red on critical or `--severity=error` findings in changed scripts); and
+          * artifacts consumed by `Maintenance: Lint scripts (post)`, which posts inline review comments and auto-fix suggestions back on the PR via [reviewdog](https://github.com/reviewdog/reviewdog).
+
+          ### Don't want this in a fork?
+
+          This workflow runs on every fork of `armbian/build` by default. To disable in your fork:
+
+          * **All Actions** — Settings → Actions → General → "Disable actions".
+          * **Just this workflow** — Settings → Actions → Workflows → "Maintenance: Lint scripts" → "Disable workflow". The companion `Maintenance: Lint scripts (post)` becomes a no-op once this one is disabled.
+
+          EOF
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -32,28 +64,103 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v46.0.5
 
-      - name: List all changed files
+      - name: Install shfmt (used by `shfmt -f .` enumerator and the drift artifact)
+        run: sudo apt-get update -qq && sudo apt-get install -y shfmt
+
+      # ============================================================
+      # Produce artifacts for the post workflow BEFORE the red-cross
+      # gate, so even a red-cross failure ships diagnostics to the PR.
+      # SHELLCHECK_INSTALL_ONLY=1 just populates the framework cache;
+      # subsequent steps reuse the binary directly.
+      # ============================================================
+      - name: ShellCheck — populate platform-detected binary cache
+        env:
+          SHELLCHECK_INSTALL_ONLY: "1"
+        run: bash lib/tools/shellcheck.sh
+
+      - name: ShellCheck — produce findings in gcc format (PR-comment artifact)
         run: |
+          # Mirror calculate_params_for_severity SEVERITY=critical from
+          # lib/tools/shellcheck.sh, emit gcc-format so the post job can
+          # parse with reviewdog -efm. compile.sh as the entry-point
+          # follows the entire source closure (--check-sourced
+          # --external-sources); SC2154 against cross-file definitions
+          # resolves correctly.
+          SC=$(find cache/tools/shellcheck -name 'shellcheck-v*' -type f -executable | head -1)
+          "$SC" \
+            --check-sourced --external-sources --shell=bash \
+            --severity=warning --format=gcc \
+            --exclude=SC2034,SC2207,SC2046,SC2086,SC2206 \
+            compile.sh \
+            > shellcheck-findings.txt 2>&1 || true
 
-          # Use framework internal mechanism for checking `lib` and `extensions` code only one file is passed,
-          # and source's are followed, thus the whole project is "understood" by shellcheck.
-          # For example, when checking individual files, one variable might be thought "unused" because it
-          # is only used in another file, which does not happen when done properly.
+      - name: ShellCheck — produce auto-fix diff (PR-suggestion artifact)
+        run: |
+          # `--severity=style` (broadest) on purpose: ShellCheck's auto-fix
+          # coverage is mostly style/info-level (SC2006, SC2196, SC2129…);
+          # --severity=warning leaves only excluded codes. filter_mode=added
+          # in the post step limits noise to lines this PR adds.
+          SC=$(find cache/tools/shellcheck -name 'shellcheck-v*' -type f -executable | head -1)
+          "$SC" -f diff \
+            --severity=style --shell=bash \
+            --exclude=SC2034,SC2207,SC2046,SC2086,SC2206 \
+            $(shfmt -f .) \
+            > shellcheck-fix.diff 2>/dev/null || true
 
+      - name: shfmt — produce drift diff (PR-suggestion artifact)
+        run: |
+          # `|| true`: shfmt aborts with exit 1 on any unparseable file
+          # (some Armbian shell scripts use bash-extension syntax that
+          # confuses the parser). Files that *did* produce diff hunks
+          # still ship to the post step.
+          shfmt -d $(shfmt -f .) > shfmt.diff 2>/dev/null || true
+
+      - name: Stash PR metadata for the post workflow
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr-number.txt
+          echo "${{ github.event.pull_request.head.sha }}" > head-sha.txt
+          echo "${{ github.event.pull_request.head.repo.full_name }}" > head-repo.txt
+          echo "${{ github.event.pull_request.base.sha }}" > base-sha.txt
+          echo "${{ github.event.pull_request.base.ref }}" > base-ref.txt
+          echo "${{ github.repository }}" > base-repo.txt
+
+      - name: Upload artifact (always — even if the red-cross gate below fails)
+        if: always()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: lint-scripts-results
+          path: |
+            shellcheck-findings.txt
+            shellcheck-fix.diff
+            shfmt.diff
+            pr-number.txt
+            head-sha.txt
+            head-repo.txt
+            base-sha.txt
+            base-ref.txt
+            base-repo.txt
+          retention-days: 1
+          if-no-files-found: error
+
+      # ============================================================
+      # Red-cross gate — preserves the previous maintenance-lint-scripts.yml
+      # pass/fail semantics: framework run (via compile.sh entry-point,
+      # follows the source chain so cross-file vars aren't reported as
+      # "unused") + per-file --severity=error on bash-shebang scripts
+      # outside lib/ and extensions/. Anything that previously turned
+      # the PR Check red still does so here.
+      # ============================================================
+      - name: Red-cross gate (framework run + critical per-file)
+        run: |
           bash lib/tools/shellcheck.sh
 
           ret=0
-
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-
-              if [[ ! "${file}" =~ lib/|extensions/|.py|.service|.rules|.network|.netdev ]]; then
-                  if grep -qE "^#\!/.*bash" $file; then
-
-                      shellcheck --severity=error $file || ret=$?
-
-                  fi
+            if [[ ! "${file}" =~ lib/|extensions/|.py|.service|.rules|.network|.netdev ]]; then
+              if grep -qE "^#\!/.*bash" "$file"; then
+                shellcheck --severity=error "$file" || ret=$?
               fi
-
+            fi
           done
 
           exit $ret

--- a/lib/tools/shellcheck.sh
+++ b/lib/tools/shellcheck.sh
@@ -52,9 +52,9 @@ if [[ ! -f "${SHELLCHECK_BIN}" ]]; then
 	echo "Down URL: ${DOWN_URL}"
 	echo "SHELLCHECK_BIN: ${SHELLCHECK_BIN}"
 	curl -fLo "${SHELLCHECK_BIN}.tar.xz" "${DOWN_URL}" || {
-		echo "download of shellcheck failed from ${DOWN_URL}";
+		echo "download of shellcheck failed from ${DOWN_URL}"
 		rm -f "${SHELLCHECK_BIN}.tar.xz"
-		exit 1;
+		exit 1
 	}
 	tar -xf "${SHELLCHECK_BIN}.tar.xz" -C "${DIR_SHELLCHECK}" "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
 	mv -v "${DIR_SHELLCHECK}/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" "${SHELLCHECK_BIN}"
@@ -62,6 +62,15 @@ if [[ ! -f "${SHELLCHECK_BIN}" ]]; then
 	chmod +x "${SHELLCHECK_BIN}"
 fi
 ACTUAL_VERSION="$("${SHELLCHECK_BIN}" --version | grep "^version")"
+
+# Install-only mode: callers that just need the binary (CI workflows
+# composing reviewdog / action-suggester on top of the framework's
+# platform-aware download cache) can short-circuit the linting passes
+# once SHELLCHECK_BIN is populated.
+if [[ -n "${SHELLCHECK_INSTALL_ONLY}" ]]; then
+	echo "SHELLCHECK_INSTALL_ONLY set, exiting after install. SHELLCHECK_BIN=${SHELLCHECK_BIN}"
+	exit 0
+fi
 
 function calculate_params_for_severity() {
 	declare SEVERITY="${SEVERITY:-"critical"}"


### PR DESCRIPTION
## What this PR does

Two complementary additions to the existing shell-script lint pipeline:

1. **Augments `maintenance-lint-scripts.yml` to export its findings as build artifacts** — the workflow continues to produce the same red-cross / green-check Check on every PR, but it also uploads the diagnostic output (gcc-format ShellCheck warnings, ShellCheck auto-fix unified diff, shfmt drift diff, and PR metadata) so a second workflow can act on it.

2. **Adds `maintenance-lint-scripts-post.yml` that consumes the artifact and posts inline PR comments** — for every diagnostic, it leaves a comment **on the exact line** in the PR's "Files changed" tab:
   * **trivial cases that ShellCheck or shfmt can auto-fix** appear as GitHub `suggestion` blocks the reviewer can apply with one click (the `Commit suggestion` button); and
   * **issues the linters can't auto-fix** appear as plain inline review comments, so the PR author sees the warning right next to the offending line.

The split into two workflows is deliberate. `pull_request` events from forks get a read-only `GITHUB_TOKEN`, so they cannot post comments; but `workflow_run` events fire in the BASE repository's context with a write token. Putting the linting in `pull_request` (read-only, safe to run arbitrary linters on PR code) and the comment posting in `workflow_run` (write-capable, never touches PR code) is the only way to deliver inline comments on fork-originating PRs. CodeQL's `actions/untrusted-checkout/high` rule stays quiet because no `actions/checkout` ever pulls PR head into the privileged context.

## Demo

Live demo PR in the fork — all four output channels firing on a single commit:
https://github.com/iav/armbian/pull/134

It adds an intentionally-broken `_shellcheck_demo()` to the bottom of `compile.sh` with four findings — SC2006 (autofix), SC2155 (no autofix), SC2154 (no autofix), shfmt drift (autofix) — and shows the resulting four PR comments: two inline review messages and two `suggestion` blocks.

The demo commit is **not** included in this PR.

---

## Changes

### `lib/tools/shellcheck.sh` — `SHELLCHECK_INSTALL_ONLY` env

Adds an early-exit env flag so CI workflows that only need the platform-detected ShellCheck binary (and the cache that the framework already maintains) can skip the linting passes themselves.

### `.github/workflows/maintenance-lint-scripts.yml` — unified lint + artifact producer

Replaces the previous Checks-only workflow. Now does both:

* the existing red-cross / green-check gate via `bash lib/tools/shellcheck.sh` plus the per-file `--severity=error` loop on changed bash-shebang scripts; and
* generation of three diagnostic artifacts consumed by the post phase:
  * `shellcheck-findings.txt` (gcc-format) — for inline review comments
  * `shellcheck-fix.diff` — for `suggestion`-block auto-fixes
  * `shfmt.diff` — for formatting-drift `suggestion` blocks
* PR-context metadata (`pr-number.txt`, `head-sha.txt`, `base-sha.txt`, `base-ref.txt`, `head-repo.txt`, `base-repo.txt`).

`upload-artifact` runs with `if: always()` so artifacts ship even when the red-cross gate fails. The `if: == 'Armbian'` guard is dropped so the workflow runs in forks too (forks that don't want it can disable via Settings → Actions → Workflows).

### `.github/workflows/maintenance-lint-scripts-post.yml` — new

Second phase, triggered by `workflow_run` on lint completion. Runs from the BASE branch with a full write token (so PR comments work for cross-fork PRs), downloads the artifact, synthesizes a minimal `pull_request` event JSON, and feeds the three artifact files to `reviewdog` in three passes (different `tool_name`s so dedupe doesn't collide between findings and suggestions).

Security model: the post job **never checks out PR head code**. It only checks out BASE (its own trusted code, needed so `reviewdog` has a local `.git` directory; the actual PR diff is fetched via the GitHub API). CodeQL's `actions/untrusted-checkout/high` rule stays quiet.

Assisted-by: Claude:claude-opus-4.7