### PR TITLE
demo: ShellCheck/shfmt PR-comment examples

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -51,3 +51,28 @@ cli_entrypoint "$@"
 
 # Log the last statement of this script for debugging purposes.
 display_alert "Armbian build script exiting" "very last thing" "cleanup"
+
+# TEST: shellcheck demo block — NOT called, only here so the new
+# maintenance-shellcheck-suggest workflow has something to flag in PR.
+# - SC2006 / SC2196: shellcheck can auto-fix these → reviewdog/action-suggester
+#   posts them as inline `suggestion` blocks.
+# - SC2154 / SC2164: shellcheck cannot auto-fix these → reviewdog posts as
+#   inline review comments without a click-to-apply suggestion.
+# Remove this block once the workflow is verified end-to-end.
+function _shellcheck_demo() {
+	# SC2006: legacy `cmd` backticks — autofix to $()
+	local kernel=`uname -r`
+
+	# SC2196: egrep is deprecated — autofix to `grep -E`
+	echo "$kernel" | egrep '^[0-9]'
+
+	# SC2154: referenced but never assigned — no autofix, review comment only.
+	echo "$undefined_var_for_demo"
+
+	# SC2164: cd may fail and the script keeps going — no autofix.
+	cd /tmp
+
+	# Note: double space + redirect with no surrounding space — only
+	# shfmt complains; shellcheck doesn't flag this.
+	echo "demo"  "value">/dev/null
+}


### PR DESCRIPTION
Demo PR for #133 — single commit adds a never-called `_shellcheck_demo()` at the bottom of `compile.sh` with four intentional issues, showing all four output channels of the new lint pipeline.

| Line | Code | Channel |
|---|---|---|
| 64 | SC2006 (legacy backticks) | inline **`suggestion` block** (click `Commit suggestion` to apply) |
| 64 | SC2155 (declare-and-assign masks return) | inline **review comment** (no auto-fix available) |
| 70 | SC2154 (referenced but not assigned) | inline **review comment** |
| 77 | shfmt drift (double space + redirect spacing) | inline **`suggestion` block** |

Plus the lint phase shows a red-cross Check on the PR (critical findings trigger gating), like the previous single-phase `maintenance-lint-scripts.yml` did.

Demo only — not for merging.