### PR TITLE
ci(lint-scripts): unify changed-files source + publish report on red-cross gate fail

### DIFF
--- a/.github/workflows/maintenance-lint-scripts.yml
+++ b/.github/workflows/maintenance-lint-scripts.yml
@@ -25,6 +25,11 @@ on:
 
 permissions:
   contents: read
+  # Required for the `gh api repos/.../pulls/N/files` call below.
+  # `contents: read` alone leaves all other scopes at `none` under
+  # fine-grained / app tokens, and the endpoint then returns
+  # `Resource not accessible by integration`.
+  pull-requests: read
 
 concurrency:
   group: pipeline-lint-${{ github.event.pull_request.number }}
@@ -60,9 +65,46 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v46.0.5
+      # PR-scope file list. Uses the GitHub PR API (merge-base diff,
+      # the same set the PR's "Files changed" tab and reviewdog's
+      # filter_mode=added operate on), not `git diff base..head` —
+      # the latter expands to every commit since the head branch
+      # forked, which on stale-rebased PRs balloons to hundreds of
+      # legacy files and produces red Checks unrelated to the PR.
+      #
+      # The list is written to `pr-changed-files.lines` as one
+      # JSON-encoded path per line. Both the `$GITHUB_OUTPUT`
+      # multiline-heredoc and the env-block alternatives are too
+      # fragile here: Git allows newlines and quotes in paths, and
+      # filename data is attacker-controlled (any PR can add any
+      # path), so any encoding that uses raw newlines as separator
+      # — or any in-script `${{ … }}` interpolation — is a route
+      # to either truncation, lost files, or command injection at
+      # parse time. JSON-per-line cleanly addresses all three: the
+      # newline separator cannot appear inside a JSON-encoded path,
+      # and consumers `jq -r .` to recover the raw string into a
+      # shell variable that already exists (no parsing of the path
+      # *as* shell code).
+      - name: Get changed files (PR-scope, merge-base)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_FILE_COUNT: ${{ github.event.pull_request.changed_files }}
+        run: |
+          # `pulls/N/files` caps at 3000 entries. Above that GitHub
+          # silently returns only a prefix, the downstream gate would
+          # lint a partial PR, and SC errors in trailing files could
+          # ship as green. Refuse loudly instead — a local merge-base
+          # fallback is possible but rarely worth carrying since PRs
+          # of this size are exceptional.
+          if (( PR_FILE_COUNT > 3000 )); then
+            echo "::error::PR changes ${PR_FILE_COUNT} files; GitHub's pulls/N/files API caps at 3000. Split the PR, or extend this workflow with a local merge-base fallback."
+            exit 1
+          fi
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename | @json' > pr-changed-files.lines
+          echo "PR-scope changed files (#${{ github.event.pull_request.number }}):"
+          jq -r . < pr-changed-files.lines | sed 's/^/  /'
 
       - name: Install shfmt (used by `shfmt -f .` enumerator and the drift artifact)
         run: sudo apt-get update -qq && sudo apt-get install -y shfmt
@@ -103,15 +145,21 @@ jobs:
           # in the red-cross gate at end of job, but their output
           # also needs to land in the artifact so the post phase can
           # inline-comment on them. Same exclusion regex as the gate.
-          CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
-          for file in $CHANGED_FILES; do
+          #
+          # Read each path as JSON (escapes embedded newlines/quotes)
+          # then jq-decode into $file. Because $file is *assigned*, not
+          # interpolated, even a path like `x"$(id)".sh` becomes a
+          # plain string here — no command substitution at parse time.
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            file=$(jq -r . <<< "$line")
             [[ -f "$file" ]] || continue
             if [[ ! "$file" =~ lib/|extensions/|\.py$|\.service$|\.rules$|\.network$|\.netdev$ ]]; then
               if grep -qE '^#!/.*bash' "$file" 2>/dev/null; then
                 "$SC" --shell=bash --severity=error --format=gcc "$file" >> shellcheck-findings.txt 2>&1 || true
               fi
             fi
-          done
+          done < pr-changed-files.lines
 
       - name: ShellCheck — produce auto-fix diff (PR-suggestion artifact)
         run: |
@@ -180,22 +228,68 @@ jobs:
       # ============================================================
       - name: Red-cross gate (framework run + critical per-file)
         run: |
-          bash lib/tools/shellcheck.sh
+          # Capture every gate diagnostic so a non-zero exit publishes
+          # a readable report (Step Summary + ::error annotations on
+          # the offending line in the Files-changed tab). Without this
+          # the only artifact of a fail is the bare job log buried
+          # under collapsed step groups.
+          gate_log="$(mktemp)"
+          trap 'rm -f "$gate_log"' EXIT
 
-          # Assign the changed-files template output into a shell
-          # variable first so its content cannot be parsed by bash as
-          # code (a malicious PR could otherwise name a file
-          # `$(cmd).sh` and execute that command on template
-          # expansion — zizmor template-injection).
-          CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
-          ret=0
-          for file in $CHANGED_FILES; do
+          set +e
+          bash lib/tools/shellcheck.sh 2>&1 | tee -a "$gate_log"
+          framework_ret=${PIPESTATUS[0]}
+
+          # Read each path as JSON-encoded (escapes newlines/quotes)
+          # then jq-decode into $file. Path content is attacker-
+          # controlled (any PR can add any filename), so it must
+          # never reach the shell parser as code — see comments on
+          # the `Get changed files` step above.
+          per_file_ret=0
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            file=$(jq -r . <<< "$line")
             [[ -f "$file" ]] || continue
             if [[ ! "$file" =~ lib/|extensions/|\.py$|\.service$|\.rules$|\.network$|\.netdev$ ]]; then
               if grep -qE '^#!/.*bash' "$file" 2>/dev/null; then
-                shellcheck --shell=bash --severity=error "$file" || ret=$?
+                # --format=gcc so the parser below can lift
+                # findings into ::error annotations.
+                shellcheck --shell=bash --severity=error --format=gcc "$file" 2>&1 | tee -a "$gate_log"
+                rc=${PIPESTATUS[0]}
+                [[ $rc -ne 0 ]] && per_file_ret=$rc
               fi
             fi
-          done
+          done < pr-changed-files.lines
+          set -e
+
+          ret=0
+          [[ $framework_ret -ne 0 ]] && ret=$framework_ret
+          [[ $per_file_ret -ne 0 ]] && ret=$per_file_ret
+
+          if [[ $ret -ne 0 ]]; then
+            # Step Summary — the readable report a PR author actually
+            # sees on the Check page.
+            {
+              echo "## Red-cross gate failed"
+              echo
+              echo "ShellCheck reported findings in PR-scope files. Details:"
+              echo
+              echo '```'
+              cat "$gate_log"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            # ::error annotations — gcc-format ⇒ inline red marker on
+            # the offending line in the PR's Files-changed tab. Match
+            # `file:line:col: error: msg` only (warnings/notes stay in
+            # the Summary block above, no inline noise).
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^(.+):([0-9]+):([0-9]+):\ error:\ (.+)$ ]]; then
+                printf '::error file=%s,line=%s,col=%s::%s\n' \
+                  "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" \
+                  "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
+              fi
+            done < "$gate_log"
+          fi
 
           exit $ret


### PR DESCRIPTION
## Summary

Two related bugs in `Maintenance: Lint scripts` surface together as
"red Check with no inline comments and no readable cause":

1. **Diverging sources of "what's changed in this PR"** —
   `tj-actions/changed-files` (here) computes `git diff base..head`
   (two-dot) and on a stale-rebased head balloons to hundreds of
   legacy files. `reviewdog -filter-mode=added` (in the post
   workflow) reads `pulls/{n}/files` — merge-base, three-dot, the
   same set the PR's "Files changed" tab shows. When the two
   disagree the gate trips on a legacy file outside the PR API set,
   the Check turns red, and reviewdog quietly drops the matching
   finding because that file isn't in *its* (smaller) added-line
   set. Author sees red with no comment and no Summary.

   **Fix:** replace the `tj-actions/changed-files` step with a tiny
   `gh api pulls/N/files` step that emits the same merge-base list
   reviewdog reads. Both the artifact loop and the red-cross gate
   now consume that single output.

2. **Gate failure swallows the diagnostic** — the gate prints
   findings to stdout, but stdout is only visible in the (collapsed)
   job log. The post workflow is the sole surface that publishes
   inline review comments, and it can no-op on its own (cross-fork
   PR with limited permissions; filter discrepancy as in (1);
   reviewdog itself failing). In those cases exit-code is the only
   signal — useful as pass/fail, useless as a diagnostic.

   **Fix:** tee the gate output to a temp log, and on `ret != 0`:
   * dump it into `$GITHUB_STEP_SUMMARY` under a fenced code block
     so the Check page shows it directly;
   * walk the gcc-format lines and emit `::error file=,line=,col=`
     annotations so each error gets an inline red marker in the
     Files-changed tab.

   Fully decoupled from the post workflow — if reviewdog never
   runs, the author still sees what failed and where.

## Repro

armbian/build PR #9461 → mirrored to iav/armbian as PR #145
(stale rebase, head from 2024-07). CI run
[26543064308](https://github.com/iav/armbian/actions/runs/26543064308)
ends with `##[error]Process completed with exit code 1` and a single
SC2199 finding on `tools/repository/repo.sh:739`. The file is *not*
in the PR API diff (which lists only `lib/functions/cli/cli-patch.sh`),
so reviewdog publishes nothing. No Summary, no inline marker — only
the bare red Check.

## Implementation notes

* Per-file ShellCheck migrated from `for file in $CHANGED_FILES`
  (word-split on `$IFS`) to `while IFS= read -r file <<<` —
  tolerates the multiline output of the new step and is safe
  against filenames with whitespace.
* `::error` annotations match only `... error: msg` lines
  (gcc-format). Warnings/notes stay in the Summary block, no
  inline noise.

## Test plan

- [x] Default Codex review on this PR.
- [x] On a clean PR — gate green, Step Summary not populated.
      Self-satisfied by this PR: run [26548639607](https://github.com/iav/armbian/actions/runs/26548639607) completed `success`.
- [ ] On a PR with a SC error in PR-scope — gate red, Step Summary
      shows the finding, inline `::error` annotation in Files-changed.
- [ ] On a stale-rebased PR like #145 — gate green (only PR-scope
      files are checked).
- [ ] If green: open upstream PR in `armbian/build`.