### PR TITLE
test(lint-scripts): synthetic SC2199 to exercise red-cross gate (do not merge)

### DIFF
--- a/tools/test-shellcheck-fail.sh
+++ b/tools/test-shellcheck-fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Synthetic shellcheck failure for self-testing the Maintenance:
+# Lint scripts gate (PR #146). Intentional SC2199. Remove together
+# with the test PR after the gate flow is verified.
+
+arr=(alpha beta gamma)
+target="alpha"
+
+# SC2199: arrays implicitly concatenate in [[ ]]; should be a loop
+# or `${arr[*]}`. This line is the whole point of the file.
+if [[ ! " ${arr[@]} " =~ " ${target} " ]]; then
+	echo "not found"
+fi

--- a/tools/test-shellcheck-fail.sh
+++ b/tools/test-shellcheck-fail.sh
@@ -11,3 +11,10 @@ target="alpha"
 if [[ ! " ${arr[@]} " =~ " ${target} " ]]; then
 	echo "not found"
 fi
+
+# Second intentional SC2199 on a fresh line, so reviewdog posts a
+# new (non-deduplicated) comment on the Conversation tab.
+other=(x y z)
+if [[ ! " ${other[@]} " =~ " ${target} " ]]; then
+	echo "still not found"
+fi


### PR DESCRIPTION
Self-test for the lint workflow shipped in #146. The file
`tools/test-shellcheck-fail.sh` contains an intentional `SC2199` on a
line outside `lib/` / `extensions/` (so it lands in the per-file gate).

Expected:
- Maintenance: Lint scripts → **red**.
- Check page Summary contains the finding under a fenced code block.
- `tools/test-shellcheck-fail.sh:14` shows an inline red marker in
  Files-changed.

To be **closed without merging** once the gate behavior is verified.