### PR TITLE
ci: add Renovate config to track pinned tool versions

### DIFF
--- a/lib/functions/general/bat-cat.sh
+++ b/lib/functions/general/bat-cat.sh
@@ -9,7 +9,7 @@
 
 function run_tool_batcat() {
 	# Default version
-	BATCAT_VERSION=${BATCAT_VERSION:-0.26.1} # https://github.com/sharkdp/bat/releases
+	BATCAT_VERSION=${BATCAT_VERSION:-0.26.1} # renovate: datasource=github-releases depName=sharkdp/bat https://github.com/sharkdp/bat/releases
 
 	declare non_cache_dir="/armbian-tools/batcat" # To deploy/reuse cached batcat in a Docker image.
 

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -9,7 +9,7 @@
 
 function run_tool_oras() {
 	# Default version
-	ORAS_VERSION=${ORAS_VERSION:-1.3.2} # https://github.com/oras-project/oras/releases
+	ORAS_VERSION=${ORAS_VERSION:-1.3.2} # renovate: datasource=github-releases depName=oras-project/oras https://github.com/oras-project/oras/releases
 	#ORAS_VERSION=${ORAS_VERSION:-"1.0.0-rc.1"} # https://github.com/oras-project/oras/releases
 
 	declare non_cache_dir="/armbian-tools/oras" # To deploy/reuse cached ORAS in a Docker image.

--- a/lib/functions/general/shellcheck.sh
+++ b/lib/functions/general/shellcheck.sh
@@ -49,7 +49,7 @@ function shellcheck_debian_control_scripts() {
 
 function run_tool_shellcheck() {
 	# Default version
-	SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.11.0} # https://github.com/koalaman/shellcheck/releases
+	SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.11.0} # renovate: datasource=github-releases depName=koalaman/shellcheck https://github.com/koalaman/shellcheck/releases
 
 	declare non_cache_dir="/armbian-tools/shellcheck" # To deploy/reuse cached SHELLCHECK in a Docker image.
 

--- a/lib/tools/shellcheck.sh
+++ b/lib/tools/shellcheck.sh
@@ -7,7 +7,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.11.0} # https://github.com/koalaman/shellcheck/releases
+SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.11.0} # renovate: datasource=github-releases depName=koalaman/shellcheck https://github.com/koalaman/shellcheck/releases
 
 SRC="$(
 	cd "$(dirname "$0")/../.."

--- a/lib/tools/shellfmt.sh
+++ b/lib/tools/shellfmt.sh
@@ -7,7 +7,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-SHELLFMT_VERSION=${SHELLFMT_VERSION:-3.13.1} # https://github.com/mvdan/sh/releases/
+SHELLFMT_VERSION=${SHELLFMT_VERSION:-3.13.1} # renovate: datasource=github-releases depName=mvdan/sh https://github.com/mvdan/sh/releases/
 
 SRC="$(
 	cd "$(dirname "$0")/../.."

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"],
+	"enabledManagers": ["custom.regex"],
+	"dependencyDashboard": true,
+	"labels": ["dependencies"],
+	"timezone": "Europe/Zagreb",
+	"schedule": ["* 1 * * 6"],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"managerFilePatterns": ["/^lib/.*\\.sh$/"],
+			"matchStrings": [
+				"_VERSION=\\$\\{[A-Z_]+:-(?<currentValue>[0-9][0-9.]*)\\}\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)"
+			],
+			"extractVersionTemplate": "^v?(?<version>.+)$",
+			"versioningTemplate": "semver"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Adds a Renovate **custom regex manager** that watches the hard-pinned CLI tool versions downloaded from GitHub releases inside the build scripts, mirroring the Dependabot model (weekly check, Dependency Dashboard, auto-opened bump PRs).

- New `renovate.json` (custom.regex manager, weekly schedule, dependency dashboard enabled).
- Inline `# renovate: datasource=github-releases depName=…` annotations added next to each pinned version.
- Scoped to `custom.regex` only, so it does not overlap with the manifest ecosystems Dependabot already handles (github-actions/docker).

## Requires installing the Renovate App

**This config does nothing on its own.** It becomes active only once the Renovate GitHub App is installed on this fork (https://github.com/apps/renovate — free for the repo via mend.io), or a self-hosted Renovate run is pointed at the repo. Until then the file is inert: no dashboard, no PRs.

After install Renovate will create an onboarding PR + a Dependency Dashboard issue, then on the weekly schedule open a PR per tool when a newer release exists.

## Tracked pins

| File | Variable | Current | Upstream |
|---|---|---|---|
| lib/tools/shellfmt.sh | SHELLFMT_VERSION | 3.13.1 | mvdan/sh |
| lib/tools/shellcheck.sh | SHELLCHECK_VERSION | 0.11.0 | koalaman/shellcheck |
| lib/functions/general/shellcheck.sh | SHELLCHECK_VERSION | 0.11.0 | koalaman/shellcheck |
| lib/functions/general/oci-oras.sh | ORAS_VERSION | 1.3.2 | oras-project/oras |
| lib/functions/general/bat-cat.sh | BATCAT_VERSION | 0.26.1 | sharkdp/bat |

shellcheck is pinned twice; both sites share depName koalaman/shellcheck, so Renovate bumps them together in one PR. `extractVersionTemplate` strips the leading `v` from upstream tags (e.g. v0.11.0) to match the bare values used here.

## Test plan

- [x] `renovate-config-validator` — "Config validated successfully"
- [ ] After app install: onboarding PR + Dependency Dashboard appear
- [ ] A bump PR opens for a tool that has a newer release