### PR TITLE
ci(renovate): keep the version-line match on a single physical line

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -88,7 +88,10 @@
 			//      and (b) add its NAME to the alternation in `matchStrings`.
 			// ════════════════════════════════════════════════════════════════
 			matchStrings: [
-				"\\b(?:SHELLFMT|SHELLCHECK|ORAS|BATCAT)_VERSION=\\$\\{[A-Z_]+:-(?<currentValue>[0-9][0-9.]*)\\}\\s*#\\s*https://github\\.com/(?<depName>[^/]+/[^/\\s]+)/releases",
+				// separator is [[:blank:]] (space/tab only, NOT \s) so the version
+				// and its release-URL comment must sit on ONE physical line —
+				// \s would also cross newlines and could grab an unrelated URL.
+				"\\b(?:SHELLFMT|SHELLCHECK|ORAS|BATCAT)_VERSION=\\$\\{[A-Z_]+:-(?<currentValue>[0-9][0-9.]*)\\}[[:blank:]]*#[[:blank:]]*https://github\\.com/(?<depName>[^/]+/[^/\\s]+)/releases",
 			],
 			datasourceTemplate: "github-releases",
 			extractVersionTemplate: "^v?(?<version>.+)$",


### PR DESCRIPTION
## Summary

Restrict the separator between a pinned version and its release-URL
comment to horizontal whitespace, so a tracked line must be a single
physical line.

The custom-regex manager used `\s` between the `}` and the
`# https://github.com/OWNER/REPO/releases` comment. Renovate runs the
regex over the whole file, and `\s` also matches newlines — so an
allow-listed `*_VERSION` that has no same-line URL could match an
unrelated release-URL comment further down the file and get tracked
under the wrong repo. Replacing `\s` with the POSIX `[[:blank:]]`
(space/tab only) confines the match to one line, matching the documented
contract.

Verified against RE2 1.24.1 (Renovate's regex engine):

| separator | same line | version on its own line + unrelated URL below |
|---|---|---|
| `\s` (before) | match | **wrongly matches the unrelated URL** |
| `[[:blank:]]` (after) | match | no match |

## Test plan

- [x] \`renovate-config-validator renovate.json5\` — Config validated successfully
- [x] RE2 match check — single-line still matches, cross-line no longer matches