### PR TITLE
(#9400 P2b) Replace echo|pipe subshells with here-strings/parameter expansion

### DIFF
--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -579,7 +579,7 @@ function uboot_postinst_base() {
 		#recognize_root
 		root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
 		root_partition=$(blkid | tr -d '":' | grep "${root_uuid}" | awk '{print $1}')
-		root_partition_name=$(echo $root_partition | sed 's/\/dev\///g')
+		root_partition_name="${root_partition#/dev/}"
 		root_partition_device_name=$(lsblk -ndo pkname $root_partition)
 		root_partition_device=/dev/$root_partition_device_name
 

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -132,7 +132,8 @@ function memoized_git_ref_to_info() {
 
 				"https://gitverse.ru/"*)
 					declare org_and_repo=""
-					org_and_repo="$(echo "${git_source}" | cut -d/ -f4-5)"
+					IFS=/ read -r _ _ _ _gr_org _gr_repo _ <<< "${git_source}"
+					org_and_repo="${_gr_org}/${_gr_repo}"
 					org_and_repo="${org_and_repo%.git}" # remove .git if present
 					url="https://gitverse.ru/api/repos/${org_and_repo}/raw/commit/${sha1}/Makefile"
 					;;
@@ -140,7 +141,8 @@ function memoized_git_ref_to_info() {
 				"https://gitee.com/"*)
 					# parse org/repo from https://gitee.com/org/repo
 					declare org_and_repo=""
-					org_and_repo="$(echo "${git_source}" | cut -d/ -f4-5)"
+					IFS=/ read -r _ _ _ _gr_org _gr_repo _ <<< "${git_source}"
+					org_and_repo="${_gr_org}/${_gr_repo}"
 					org_and_repo="${org_and_repo%.git}" # remove .git if present
 					url="https://gitee.com/${org_and_repo}/raw/${sha1}/Makefile"
 					;;
@@ -148,7 +150,8 @@ function memoized_git_ref_to_info() {
 				"https://github.com/"*)
 					# parse org/repo from https://github.com/org/repo
 					declare org_and_repo=""
-					org_and_repo="$(echo "${git_source}" | cut -d/ -f4-5)"
+					IFS=/ read -r _ _ _ _gr_org _gr_repo _ <<< "${git_source}"
+					org_and_repo="${_gr_org}/${_gr_repo}"
 					org_and_repo="${org_and_repo%.git}" # remove .git if present
 					case "${GITHUB_MIRROR}" in
 						"ghproxy")

--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -86,7 +86,9 @@ function fetch_from_repo() {
 	local git_work_dir
 
 	# Set GitHub mirror before anything else touches $url
-	url="$(echo "$url" | sed "s|^https://github.com/|${GITHUB_SOURCE}/|")"
+	if [[ "${url}" == https://github.com/* ]]; then
+		url="${GITHUB_SOURCE}/${url#https://github.com/}"
+	fi
 
 	# The 'offline' variable must always be set to 'true' or 'false'
 	local offline=false

--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -279,8 +279,8 @@ function fetch_from_repo() {
 				while read -r key path; do
 					# key is like: submodule.libfoo.path
 					# extract "libfoo" from "submodule.libfoo.path"
-					local name=${key#submodule.}   # -> libfoo.path
-					name=${name%.path}             # -> libfoo
+					local name=${key#submodule.} # -> libfoo.path
+					name=${name%.path}           # -> libfoo
 
 					cd "${git_work_dir}" || exit
 

--- a/lib/functions/general/hash-files.sh
+++ b/lib/functions/general/hash-files.sh
@@ -72,8 +72,8 @@ function calculate_hash_for_files() {
 
 	declare full_hash
 	full_hash="$(cd "${SRC}" && sha256sum "${files_to_hash_sorted[@]}")"
-	hash_files="$(echo "${full_hash}" | sha256sum | cut -d' ' -f1)" # hash of hashes
-	hash_files="${hash_files:0:16}"                                 # shorten it to 16 characters
+	hash_files="$(sha256sum <<< "${full_hash}" | cut -d' ' -f1)" # hash of hashes
+	hash_files="${hash_files:0:16}"                              # shorten it to 16 characters
 
 	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
 		display_alert "Hash for files:" "$hash_files" "debug"
@@ -95,7 +95,7 @@ function calculate_hash_for_function_bodies() {
 	if [[ ${#function_bodies[@]} -eq 0 ]]; then
 		hash_functions="0000000000000000"
 	else
-		hash_functions="$(echo "${function_bodies[@]}" | sha256sum | cut -d' ' -f1)"
+		hash_functions="$(sha256sum <<< "${function_bodies[*]}" | cut -d' ' -f1)"
 	fi
 	return 0
 }
@@ -113,7 +113,7 @@ function calculate_hash_for_variables() {
 		all_values="${all_values//${SRC}/}" # remove all occurences of ${SRC} from all_values
 	fi
 
-	hash_variables="$(echo "${all_values}" | sha256sum | cut -d' ' -f1)" # outer scope
+	hash_variables="$(sha256sum <<< "${all_values}" | cut -d' ' -f1)" # outer scope
 	display_alert "calculate_hash_for_variables all_values_pre_normalize" "${all_values_pre_normalize}" "debug"
 	if [[ "${do_normalize_src_path:-"yes"}" == "yes" ]]; then
 		display_alert "calculate_hash_for_variables               normalized" "${all_values}" "debug"

--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -42,7 +42,8 @@ function prepare_python_and_pip() {
 
 	declare python3_version_majorminor python3_version_string
 	# Extract the major and minor version numbers (e.g., "3.12" instead of "3.12.2")
-	python3_version_majorminor=$(echo "${python3_version_full}" | awk '{print $2}' | cut -d. -f1,2)
+	declare _py_ver_triplet="${python3_version_full#* }" # strip "Python " prefix → "3.12.2"
+	python3_version_majorminor="${_py_ver_triplet%.*}"   # strip ".PATCH" suffix → "3.12"
 	# Construct the version string (e.g., "python3.12")
 	python3_version_string="python$python3_version_majorminor"
 

--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -127,15 +127,15 @@ function prepare_python_and_pip() {
 		# Install pip, using get-pip.py; that bootstraps pip using an embedded, temporary, pip contained in get-pip.py
 		display_alert "Installing pip using get-pip.py" "${pip3_version_number}" "info"
 		declare -a python_proxy_env=(
-		"http_proxy=${http_proxy:-${HTTP_PROXY:-}}"
-		"https_proxy=${https_proxy:-${HTTPS_PROXY:-}}"
-		"HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}"
-		"HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}"
-		"ftp_proxy=${ftp_proxy:-${FTP_PROXY:-}}"
-		"FTP_PROXY=${FTP_PROXY:-${ftp_proxy:-}}"
-		"no_proxy=${no_proxy:-${NO_PROXY:-}}"
-		"NO_PROXY=${NO_PROXY:-${no_proxy:-}}"
-		"APT_PROXY_ADDR=${APT_PROXY_ADDR:-}"
+			"http_proxy=${http_proxy:-${HTTP_PROXY:-}}"
+			"https_proxy=${https_proxy:-${HTTPS_PROXY:-}}"
+			"HTTP_PROXY=${HTTP_PROXY:-${http_proxy:-}}"
+			"HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy:-}}"
+			"ftp_proxy=${ftp_proxy:-${FTP_PROXY:-}}"
+			"FTP_PROXY=${FTP_PROXY:-${ftp_proxy:-}}"
+			"no_proxy=${no_proxy:-${NO_PROXY:-}}"
+			"NO_PROXY=${NO_PROXY:-${no_proxy:-}}"
+			"APT_PROXY_ADDR=${APT_PROXY_ADDR:-}"
 		)
 		run_host_command_logged env -i "${python_proxy_env[@]@Q}" "${PYTHON3_VARS[@]@Q}" "${PYTHON3_INFO[BIN]}" "${PYTHON3_INFO[GET_PIP_BIN]}" "${pip3_extra_args[@]}" "pip==${pip3_version_number}"
 

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -180,26 +180,26 @@ function docker_cli_prepare() {
 	# Detect some docker info; use cached.
 	get_docker_info_once
 
-	DOCKER_SERVER_VERSION="$(echo "${DOCKER_INFO}" | grep -i -e "Server Version:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_VERSION="$(grep -i -e "Server Version:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server version" "${DOCKER_SERVER_VERSION}" "debug"
 
-	DOCKER_SERVER_KERNEL_VERSION="$(echo "${DOCKER_INFO}" | grep -i -e "Kernel Version:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_KERNEL_VERSION="$(grep -i -e "Kernel Version:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server Kernel version" "${DOCKER_SERVER_KERNEL_VERSION}" "debug"
 
-	DOCKER_SERVER_TOTAL_RAM="$(echo "${DOCKER_INFO}" | grep -i -e "Total memory:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_TOTAL_RAM="$(grep -i -e "Total memory:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server Total RAM" "${DOCKER_SERVER_TOTAL_RAM}" "debug"
 
-	DOCKER_SERVER_CPUS="$(echo "${DOCKER_INFO}" | grep -i -e "CPUs:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_CPUS="$(grep -i -e "CPUs:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server CPUs" "${DOCKER_SERVER_CPUS}" "debug"
 
-	DOCKER_SERVER_OS="$(echo "${DOCKER_INFO}" | grep -i -e "Operating System:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_OS="$(grep -i -e "Operating System:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server OS" "${DOCKER_SERVER_OS}" "debug"
 
 	declare -g DOCKER_ARMBIAN_HOST_OS_UNAME
 	DOCKER_ARMBIAN_HOST_OS_UNAME="$(uname)"
 	display_alert "Local uname" "${DOCKER_ARMBIAN_HOST_OS_UNAME}" "debug"
 
-	DOCKER_BUILDX_VERSION="$(echo "${DOCKER_INFO}" | grep -i -e "buildx:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_BUILDX_VERSION="$(grep -i -e "buildx:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Buildx version" "${DOCKER_BUILDX_VERSION}" "debug"
 
 	declare -g DOCKER_HAS_BUILDX=no
@@ -210,7 +210,7 @@ function docker_cli_prepare() {
 	fi
 	display_alert "Docker has buildx?" "${DOCKER_HAS_BUILDX}" "debug"
 
-	DOCKER_SERVER_NAME_HOST="$(echo "${DOCKER_INFO}" | grep -i -e "name:" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_NAME_HOST="$(grep -i -e "name:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server Hostname" "${DOCKER_SERVER_NAME_HOST}" "debug"
 
 	# Gymnastics: under Darwin, Docker Desktop and Rancher Desktop in dockerd mode behave differently.

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -62,7 +62,6 @@ function get_docker_info_once() {
 		fi
 		declare -g -r DOCKER_IS_PODMAN="${DOCKER_IS_PODMAN}" # readonly
 
-
 		declare -g DOCKER_INFO_OK="no"
 		if [[ "${DOCKER_INFO}" =~ "DOCKER_INFO_OK" ]]; then
 			DOCKER_INFO_OK="yes"
@@ -535,7 +534,7 @@ function docker_cli_prepare_launch() {
 	while IFS= read -r _dns_server; do
 		[[ "${_dns_server}" =~ ^127\. || "${_dns_server}" == "::1" || "${_dns_server}" =~ ^fe80: ]] && continue
 		DOCKER_ARGS+=("--dns" "${_dns_server}")
-	done < <(awk '/^nameserver/ {print $2}' "${_dns_resolv_file}" 2>/dev/null)
+	done < <(awk '/^nameserver/ {print $2}' "${_dns_resolv_file}" 2> /dev/null)
 
 	# DOCKER_PRIVILEGED=no switches to a narrow capability set.
 	if [[ "${DOCKER_PRIVILEGED:-yes}" == "yes" ]]; then
@@ -800,7 +799,7 @@ function docker_cleanup_old_images() {
 
 		# Remove images beyond the first 2 (keep newest 2)
 		if [[ ${#image_ids[@]} -gt 2 ]]; then
-			for ((i=2; i<${#image_ids[@]}; i++)); do
+			for ((i = 2; i < ${#image_ids[@]}; i++)); do
 				display_alert "Removing old image" "${image_tag}:${image_ids[$i]}" "debug"
 				docker rmi "${image_ids[$i]}" > /dev/null 2>&1 || true
 			done

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -210,7 +210,7 @@ function docker_cli_prepare() {
 	fi
 	display_alert "Docker has buildx?" "${DOCKER_HAS_BUILDX}" "debug"
 
-	DOCKER_SERVER_NAME_HOST="$(grep -i -e "name:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
+	DOCKER_SERVER_NAME_HOST="$(grep -im1 -e "^ *Name:" <<< "${DOCKER_INFO}" | cut -d ":" -f 2 | xargs echo -n)"
 	display_alert "Docker Server Hostname" "${DOCKER_SERVER_NAME_HOST}" "debug"
 
 	# Gymnastics: under Darwin, Docker Desktop and Rancher Desktop in dockerd mode behave differently.

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -247,7 +247,13 @@ function prepare_partitions() {
 
 		# Check sfdisk version to determine if --sector-size is supported
 		sfdisk_version=$(sfdisk --version | awk '/util-linux/ {print $NF}')
-		sfdisk_version_num=$(echo "$sfdisk_version" | awk -F. '{printf "%d%02d%02d\n", $1, $2, $3}')
+		IFS=. read -r _sfd_maj _sfd_min _sfd_patch _ <<< "${sfdisk_version}"
+		# Strip any non-numeric suffix (e.g. "2.41-rc1" -> minor "41", not "41-rc1")
+		# so `printf %d` never bombs under `set -e` on prerelease util-linux builds.
+		_sfd_maj="${_sfd_maj%%[!0-9]*}"
+		_sfd_min="${_sfd_min%%[!0-9]*}"
+		_sfd_patch="${_sfd_patch%%[!0-9]*}"
+		printf -v sfdisk_version_num '%d%02d%02d' "${_sfd_maj:-0}" "${_sfd_min:-0}" "${_sfd_patch:-0}"
 		if [[ "$sfdisk_version_num" -ge "24100" ]]; then
 			echo "${partition_script_output}" | run_host_command_logged sfdisk --sector-size "$SECTOR_SIZE" "${SDCARD}".raw || exit_with_error "Partitioning failed!"
 		else


### PR DESCRIPTION
## Summary

Closes the last open group from #9400 (the Bash syntax safety cleanup) — P2b:
seventeen `echo "$var" | grep/sed/cut/awk/sha256sum …` chains across seven
files, replaced with bash-native here-strings or parameter expansions. Each
chain forked a subshell and one or two external processes just to do
something bash can do in-place; behavior is preserved verbatim.

[GitHub issue](https://github.com/armbian/build/issues/9400) reference: #9400

## Changes

| File | Sites | Before | After |
|---|---:|---|---|
| `lib/functions/compilation/uboot.sh` | 1 | `echo $root_partition \| sed 's/\/dev\///g'` | `"${root_partition#/dev/}"` |
| `lib/functions/general/python-tools.sh` | 1 | `$(echo … \| awk '{print $2}' \| cut -d. -f1,2)` | two parameter expansions (`${var#* }` then `${_%.*}`) |
| `lib/functions/image/partitioning.sh` | 1 | `$(echo "$ver" \| awk -F. …)` | `IFS=. read` + `printf -v` |
| `lib/functions/general/git.sh` | 1 | `$(echo "$url" \| sed "s\|^https://github.com/\|…")` | guarded prefix trim (`[[ "${url}" == https://github.com/* ]]` + `${url#…}`) |
| `lib/functions/general/git-ref2info.sh` | 3 | `$(echo "${git_source}" \| cut -d/ -f4-5)` (×3) | `IFS=/ read -r _ _ _ org repo _` |
| `lib/functions/general/hash-files.sh` | 3 | `$(echo "${x}" \| sha256sum \| cut -d' ' -f1)` (×3) | `$(sha256sum <<< "${x}" \| cut -d' ' -f1)` |
| `lib/functions/host/docker.sh` | 7 | `$(echo "${DOCKER_INFO}" \| grep -i -e "K:" \| cut -d : -f 2 \| xargs echo -n)` (×7) | `$(grep -i -e "K:" <<< "${DOCKER_INFO}" \| …)` |

## Why this matters

Each removed `echo \| …` chain saves one subshell and one external process
per call. `get_docker_info_once` alone runs seven of these in a tight
sequence at the top of every Docker-mode build; `hash-files` ones run on
every artifact hash computation. The overall wall-clock benefit is modest,
but the diff value is largely about readability and not pretending shell
needs `awk`/`sed`/`echo` for trivial string surgery.

## Note on `hash-files.sh` (was excluded in #9400, now included)

The original #9400 P2b excluded `echo "${x}" | sha256sum`, on the assumption
that the `<<<` here-string alternative would append a different trailing
newline and so change the hash. Empirically that is not the case: both
`echo "$x" | sha256sum` and `sha256sum <<< "$x"` emit one trailing `\n`
and produce identical hashes — only `printf '%s' "$x" | sha256sum` (no
newline) differs. The exclusion has been removed from #9400 accordingly,
and the three `hash-files.sh` sites are converted here.

## Preparatory style commits

Three `style(shellfmt): …` commits are carried in this PR ahead of the
functional changes they touch. They are pure shellfmt runs over the same
file: re-indented `python_proxy_env` array elements, collapsed comment
alignment in a `git.sh` submodule loop, and a tree-wide format of
`docker.sh` (which had drifted significantly from shellfmt's rules). They
are split out so each P2b commit is purely functional.

## Out of scope (deliberately)

- `[[ -z $var ]]` quoting (issue #9400 excludes this — `[[ ]]` already
  prevents word splitting; pure style preference).
- Other `eval` machinery in extension / artifact code (architectural,
  excluded by #9400).
- The unused `root_partition_name` assignment in `uboot.sh` (dead-code
  cleanup belongs in a separate change).

## Test plan

- [x] `bash lib/tools/shellcheck.sh` over the whole tree — clean.
- [x] Hash-equivalence of `echo "$x" | sha256sum` vs `sha256sum <<< "$x"`
      verified empirically with three sample inputs.
- [x] Docker info field parsing verified equivalent old vs new pattern.
- [ ] Smoke `compile.sh` Docker build (to exercise the `docker.sh`
      `get_docker_info_once` field reads).