### PR TITLE
spacemit: rtl8852bs: guard GCC-only warning flags for clang builds 

### DIFF
--- a/patch/kernel/archive/spacemit-6.18/020-rtl8852bs-guard-gcc-only-warnings-for-clang.patch
+++ b/patch/kernel/archive/spacemit-6.18/020-rtl8852bs-guard-gcc-only-warnings-for-clang.patch
@@ -1,0 +1,46 @@
+From: Igor Velkov <iav@iav.lv>
+Date: Mon, 6 Jul 2026 00:00:00 +0000
+Subject: [PATCH] rtl8852bs: guard GCC-only warning flags for clang builds
+
+The bundled rtl8852bs Makefile adds -Wno-restrict and
+-Wno-old-style-declaration unconditionally. Both warning options exist
+only in GCC; clang rejects them and, together with the kernel's
+-Werror=unknown-warning-option, the build fails:
+
+    error: unknown warning option '-Wno-restrict'
+    error: unknown warning option '-Wno-old-style-declaration'
+
+On spacemit the rtl8852bs driver is in-tree (EXTRAWIFI is forced off in
+the family config), so this breaks every clang kernel build for the
+family.
+
+Wrap the two flags in $(call cc-disable-warning, ...) so each is added
+only when the compiler understands the positive warning name, i.e. for
+GCC. This is also robust against CC carrying a ccache prefix, unlike the
+existing 'ifeq ($(CC), clang)' string comparison further down the file.
+The remaining -Wno-* flags in this block (unused, empty-body,
+missing-prototypes, missing-declarations) are understood by clang too and
+are left untouched.
+
+Signed-off-by: Igor Velkov <iav@iav.lv>
+---
+ drivers/net/wireless/realtek/rtl8852bs/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8852bs/Makefile b/drivers/net/wireless/realtek/rtl8852bs/Makefile
+--- a/drivers/net/wireless/realtek/rtl8852bs/Makefile
++++ b/drivers/net/wireless/realtek/rtl8852bs/Makefile
+@@ -14,11 +14,11 @@ ccflags-y += -Wno-unused-variable
+ #ccflags-y += -Wno-unused-function
+ ccflags-y += -Wno-unused
+ #ccflags-y += -Wno-uninitialized
+-ccflags-y += -Wno-restrict
++ccflags-y += $(call cc-disable-warning, restrict)
+ ccflags-y += -Wno-empty-body
+ ccflags-y += -Wno-missing-prototypes
+ ccflags-y += -Wno-missing-declarations
+-ccflags-y += -Wno-old-style-declaration
++ccflags-y += $(call cc-disable-warning, old-style-declaration)
+
+ ############ ANDROID COMMON KERNEL ############
+ # clang


### PR DESCRIPTION
## Problem

The rtl8852bs driver bundled in the spacemit vendor kernel adds two GCC-only warning options unconditionally in its `Makefile`:
 
```make
ccflags-y += -Wno-restrict
ccflags-y += -Wno-old-style-declaration
```

clang does not know these options, and with the kernel's `-Werror=unknown-warning-option` the build fails:

```
error: unknown warning option '-Wno-restrict' [-Werror,-Wunknown-warning-option]
error: unknown warning option '-Wno-old-style-declaration'
```

On the `spacemit` family the driver is in-tree and `EXTRAWIFI` is forced off in the family config, so it cannot be excluded. This breaks **every** clang kernel build for the family.

## Fix

Wrap the two GCC-only flags in `$(call cc-disable-warning, ...)`, so each is added only for a compiler that understands the positive warning name (GCC). This is also robust against `CC` carrying a `ccache` prefix, unlike the `ifeq ($(CC), clang)` compare further down the same Makefile. The remaining `-Wno-*` in that block (`unused`, `empty-body`, `missing-prototypes`, `missing-declarations`) are understood by clang and left untouched. GCC behavior is unchanged.

## Verification (bananapif3, kernel 6.18)

- [x] **GCC** full build: rtl8852bs (372 objects) + `8852bs.ko` + `linux-image` .deb — 0 errors.
- [x] **clang** full build with the driver enabled: `8852bs.ko` built under clang, 0 `unknown-warning-option` / 0 errors, `linux-image` .deb produced.

Repro:

```
./compile.sh kernel BOARD=bananapif3 BRANCH=current KERNEL_COMPILER=clang
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only build fix with no driver logic changes; GCC warning suppression is unchanged when those warnings exist.
> 
> **Overview**
> Adds a **spacemit 6.18** kernel patch so the in-tree **rtl8852bs** driver no longer passes unconditional `-Wno-restrict` and `-Wno-old-style-declaration` in its `Makefile`. Those options are **GCC-only**; with the kernel’s `-Werror=unknown-warning-option`, **clang** builds for the spacemit family fail while the driver stays enabled.
> 
> Each flag is replaced with **`$(call cc-disable-warning, …)`**, so the suppressor is emitted only when the active compiler supports the warning—preserving GCC behavior while letting clang build. Other `-Wno-*` lines in the same block are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1fcacb746831f29ffde05b1a2db92bb166ae40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->