### PR TITLE
uwe5622: fix clang -Wincompatible-pointer-types-discards-qualifiers

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -602,6 +602,18 @@ driver_uwe5622() {
 		fi
 
 		process_patch_file "${SRC}/patch/misc/wireless-uwe5622/wireless-uwe5622-Fix-missing-prototypes.patch" "applying"
+
+		# net_device.dev_addr is const upstream; on rockchip the in-tree helper
+		# writes it directly (adjust-for-rockchip), so passing/reading it as a
+		# plain u8 * breaks clang -Werror. sun* is already handled by
+		# fix-setting-mac-address-for-netdev; on >= 6.19 the memcpy/cfg80211
+		# sites are already converted by uwe5622-v6.19.
+		if [[ "$LINUXFAMILY" == rockchip* || "$LINUXFAMILY" == "rk35xx" ]]; then
+			process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-rockchip-clang-callsite.patch" "applying"
+			if linux-version compare "${version}" lt 6.19; then
+				process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-rockchip-clang-pre619.patch" "applying"
+			fi
+		fi
 	fi
 }
 

--- a/patch/misc/wireless-uwe5622/uwe5622-rockchip-clang-callsite.patch
+++ b/patch/misc/wireless-uwe5622/uwe5622-rockchip-clang-callsite.patch
@@ -1,0 +1,35 @@
+From: Armbian <info@armbian.com>
+Date: Mon, 7 Jul 2026 00:00:00 +0000
+Subject: [PATCH] uwe5622: cast const dev_addr at sprdwl_set_mac_addr call (clang)
+
+net_device.dev_addr became const (const unsigned char *) upstream.
+sprdwl_register_netdev() passes it to sprdwl_set_mac_addr() as a writable
+u8 * output buffer, which clang rejects under
+-Werror,-Wincompatible-pointer-types-discards-qualifiers. GCC only warned.
+
+On rockchip the helper also writes ndev->dev_addr directly via
+dev_addr_set() (see uwe5622-adjust-for-rockchip-post-6.1), while its other
+branches fill the passed buffer, so the buffer must alias ndev->dev_addr.
+Cast away const at the call site to keep that aliasing; behaviour is
+identical to the pre-const code. The call runs before register_netdevice(),
+so no dev_addr shadow tree exists yet.
+
+This site is not touched by the sun*-only fix-setting-mac-address patch nor
+by uwe5622-v6.19, so it is applied for rockchip/rk35xx across the range.
+
+Signed-off-by: Armbian <info@armbian.com>
+---
+ drivers/net/wireless/uwe5622/unisocwifi/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/uwe5622/unisocwifi/main.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/main.c
+@@ -1448,7 +1448,7 @@
+ 	ndev->features |= NETIF_F_SG;
+ 	SET_NETDEV_DEV(ndev, wiphy_dev(priv->wiphy));
+ 
+-	sprdwl_set_mac_addr(vif, addr, ndev->dev_addr);
++	sprdwl_set_mac_addr(vif, addr, (u8 *)ndev->dev_addr);
+ 
+ #ifdef CONFIG_P2P_INTF
+ 	if (type == NL80211_IFTYPE_P2P_DEVICE)

--- a/patch/misc/wireless-uwe5622/uwe5622-rockchip-clang-pre619.patch
+++ b/patch/misc/wireless-uwe5622/uwe5622-rockchip-clang-pre619.patch
@@ -1,0 +1,51 @@
+From: Armbian <info@armbian.com>
+Date: Mon, 7 Jul 2026 00:00:00 +0000
+Subject: [PATCH] uwe5622: fix const dev_addr memcpy/read for clang (< 6.19)
+
+net_device.dev_addr became const (const unsigned char *) upstream. On
+kernels before 6.19 the driver still writes it with memcpy() and reads it
+into a plain u8 *, which clang rejects under
+-Werror,-Wincompatible-pointer-types-discards-qualifiers. GCC only warned.
+
+- sprdwl_set_random_mac(): the two memcpy(dev->dev_addr, ...) writes become
+  dev_addr_set() (already used elsewhere in this driver).
+- cfg80211.c: dev_addr is only read here (handed to firmware), so cast to
+  u8 * at the point of use.
+
+From 6.19 on, uwe5622-v6.19 already converts both sites, so this patch is
+only applied for kernels < 6.19.
+
+Signed-off-by: Armbian <info@armbian.com>
+---
+ drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c | 2 +-
+ drivers/net/wireless/uwe5622/unisocwifi/main.c     | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/wireless/uwe5622/unisocwifi/main.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/main.c
+@@ -944,12 +944,12 @@
+ 		if (!is_zero_ether_addr(sa->sa_data)) {
+ 			vif->has_rand_mac = true;
+ 			memcpy(vif->random_mac, sa->sa_data, ETH_ALEN);
+-			memcpy(dev->dev_addr, sa->sa_data, ETH_ALEN);
++			dev_addr_set(dev, sa->sa_data);
+ 		} else {
+ 			vif->has_rand_mac = false;
+ 			netdev_info(dev, "need clear random mac for sta/softap mode\n");
+ 			memset(vif->random_mac, 0, ETH_ALEN);
+-			memcpy(dev->dev_addr, vif->mac, ETH_ALEN);
++			dev_addr_set(dev, vif->mac);
+ 		}
+ 	}
+ 	/*return success to pass vts test*/
+--- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
+@@ -429,7 +429,7 @@
+ 	if (!vif->ndev)
+ 		mac = vif->wdev.address;
+ 	else
+-		mac = vif->ndev->dev_addr;
++		mac = (u8 *)vif->ndev->dev_addr;
+ 
+ 	if (sprdwl_open_fw(priv, &vif_ctx_id, vif->mode, mac)) {
+ 		wl_ndev_log(L_ERR, vif->ndev, "%s failed!\n", __func__);


### PR DESCRIPTION
## Problem

`net_device.dev_addr` became `const unsigned char *` upstream. On rockchip/rk35xx the carried uwe5622 driver still writes it via `memcpy()`, passes it to `sprdwl_set_mac_addr()` as a writable output buffer, and reads it into a plain `u8 *`, all rejected by clang under `-Werror,-Wincompatible-pointer-types-discards-qualifiers`. GCC only warned, so this stayed latent until clang builds enforced it.

## Fix

The const-discard sites are already handled in some contexts by existing patches — `uwe5622-fix-setting-mac-address-for-netdev` (sun\* only) rewrites the call site, and `uwe5622-v6.19` converts the `memcpy`/cfg80211 sites from 6.19 on. So the fix is **split and gated to the contexts where the original lines survive**, applied from `driver_uwe5622()` for `rockchip*/rk35xx` only:

- `uwe5622-rockchip-clang-callsite.patch` — the `sprdwl_set_mac_addr()` call site. On rockchip the helper writes `ndev->dev_addr` directly via `dev_addr_set()` (from `adjust-for-rockchip`) *and* fills the passed buffer in its other branches, so the buffer must alias `dev_addr`; cast away const at the call site (behaviour identical to the pre-const code; the call runs before `register_netdevice()`, so no `dev_addr` shadow tree exists yet). Applied across the whole version range — nothing else touches the call site on rockchip.
- `uwe5622-rockchip-clang-pre619.patch` — the two `memcpy(dev->dev_addr, ...)` writes → `dev_addr_set()`, and the cfg80211 read cast. Applied **only for kernels `< 6.19`**, since `uwe5622-v6.19` already converts both sites from 6.19 on.

sun\* builds are left untouched.

## Verification

Clean rockchip64 clang rebuilds in progress:
- 6.18 (< 6.19): exercises both patches (call-site + pre619).
- 7.1 (≥ 6.19): only the call-site patch applies (`uwe5622-v6.19` handles the rest); confirms the pre619 patch is correctly gated out.
