### PR TITLE
odroidm1: bump u-boot to v2026.07

### DIFF
--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -14,8 +14,8 @@ IMAGE_PARTITION_TABLE="gpt"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 
-BOOTBRANCH_BOARD="tag:v2026.01"
-BOOTPATCHDIR="v2026.01" # but all changes are done in this board file, not patches
+BOOTBRANCH_BOARD="tag:v2026.07"
+BOOTPATCHDIR="v2026.07" # but all changes are done in this board file, not patches
 
 BOOTCONFIG="odroid-m1-rk3568_defconfig"
 BOOTDIR="u-boot-${BOARD}"

--- a/patch/u-boot/v2026.07/0001-pci-pcie_dw_rockchip-increase-PCIe-LTSSM-timeout-for-cold-boot.patch
+++ b/patch/u-boot/v2026.07/0001-pci-pcie_dw_rockchip-increase-PCIe-LTSSM-timeout-for-cold-boot.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Pahle <robert.pahle@gmail.com>
+Date: Wed, 06 May 2026 00:00:00 +0000
+Subject: [PATCH] pci: pcie_dw_rockchip: increase PCIe retry count for Rock 5B cold boot
+
+On RK3588 (Rock 5B), NVMe drives fail to enumerate after a cold boot
+(complete power loss) because the PCIe link does not train within the
+original 10-retry / 1s window. Warm boots succeed because the NVMe
+retains power and is already initialized when LTSSM starts.
+
+Increase the retry count from 10 to 25 (2.5s total at 100ms per retry).
+The pre-PERST stabilization delay remains at 100ms so warm-boot
+performance is unaffected — the extra time is only consumed when the
+link fails to come up on the first few attempts, which only occurs on
+a cold boot where the NVMe needs time to stabilize after power-on.
+
+Signed-off-by: Robert Pahle <robert.pahle@gmail.com>
+---
+ drivers/pci/pcie_dw_rockchip.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pci/pcie_dw_rockchip.c b/drivers/pci/pcie_dw_rockchip.c
+index 208aa30463a..11c4480f4b0 100644
+--- a/drivers/pci/pcie_dw_rockchip.c
++++ b/drivers/pci/pcie_dw_rockchip.c
+@@ -269,14 +269,14 @@ static int rk_pcie_link_up(struct rk_pcie *priv)
+ 		dm_gpio_set_value(&priv->rst_gpio, 1);
+ 
+ 	/* Check if the link is up or not */
+-	for (retries = 0; retries < 10; retries++) {
++	for (retries = 0; retries < 25; retries++) {
+ 		if (is_link_up(priv))
+ 			break;
+ 
+ 		mdelay(100);
+ 	}
+ 
+-	if (retries >= 10) {
++	if (retries >= 25) {
+ 		dev_err(priv->dw.dev, "PCIe-%d Link Fail\n",
+ 			dev_seq(priv->dw.dev));
+ 		return -EIO;

--- a/patch/u-boot/v2026.07/general-fix-btrfs-zstd-decompression.patch
+++ b/patch/u-boot/v2026.07/general-fix-btrfs-zstd-decompression.patch
@@ -1,0 +1,119 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Velkov <iav-armbian@draconpern.com>
+Date: Thu, 10 Apr 2026 00:00:00 +0000
+Subject: [PATCH] fs: btrfs: fix zstd decompression for BTRFS extents
+
+The generic zstd_decompress() wrapper in lib/zstd/zstd.c works for FIT
+images but fails for BTRFS filesystem extents due to two issues:
+
+1. Sector-aligned compressed size: BTRFS stores compressed extents
+   padded to sector boundaries (4096 bytes).  The on-disk size
+   (disk_num_bytes) may be larger than the actual zstd frame.
+   zstd_decompress_dctx() rejects trailing data after the frame,
+   causing decompression failures for regular (non-inline) extents.
+
+2. Sector-aligned decompressed size: BTRFS compresses in sector-sized
+   blocks, so the zstd frame content size may exceed the actual data
+   size (ram_bytes) stored in extent metadata.  For example, a 3906
+   byte file is compressed as a 4096 byte block.  When the output
+   buffer is sized to ram_bytes, zstd_decompress_dctx() fails with
+   ZSTD_error_dstSize_tooSmall (error 70) for inline extents.
+
+Both issues manifest as boot failures on zstd-compressed BTRFS:
+
+  zstd_decompress: failed to decompress: 70
+  BTRFS: An error occurred while reading file /boot/boot.scr
+
+Fix by calling zstd_decompress_dctx() directly with two adjustments:
+- Use zstd_find_frame_compressed_size() to strip sector padding from
+  the input, giving zstd the exact frame size.
+- Use ZSTD_getFrameContentSize() to detect when the frame decompresses
+  to more than dlen bytes, and allocate a temporary buffer for the
+  full decompressed frame when needed.
+
+This is consistent with decompress_lzo() and decompress_zlib() which
+also call their library functions directly without generic wrappers.
+
+Signed-off-by: Igor Velkov <iav-armbian@draconpern.com>
+---
+ fs/btrfs/compression.c | 66 +++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 62 insertions(+), 4 deletions(-)
+
+diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
+--- a/fs/btrfs/compression.c
++++ b/fs/btrfs/compression.c
+@@ -137,12 +137,70 @@
+
+ static u32 decompress_zstd(const u8 *cbuf, u32 clen, u8 *dbuf, u32 dlen)
+ {
+-	struct abuf in, out;
++	zstd_dctx *ctx;
++	size_t wsize, ret, frame_csize, out_len;
++	void *workspace;
++	unsigned long long fcs;
++	u8 *tmp = NULL;
++	u8 *out_buf = dbuf;
++
++	out_len = dlen;
+
+-	abuf_init_set(&in, (u8 *)cbuf, clen);
+-	abuf_init_set(&out, dbuf, dlen);
++	/*
++	 * Find the actual compressed frame size. BTRFS stores compressed
++	 * extents padded to sector boundaries, but zstd_decompress_dctx()
++	 * requires the exact frame size without trailing padding.
++	 */
++	frame_csize = zstd_find_frame_compressed_size(cbuf, clen);
++	if (!zstd_is_error(frame_csize))
++		clen = frame_csize;
+
+-	return zstd_decompress(&in, &out);
++	/*
++	 * BTRFS compresses in sector-sized blocks, so the zstd frame may
++	 * decompress to a full sector (e.g. 4096) even when the actual
++	 * data (ram_bytes) is smaller. Allocate a larger buffer when needed
++	 * to avoid ZSTD_error_dstSize_tooSmall.
++	 */
++	fcs = ZSTD_getFrameContentSize(cbuf, clen);
++	if (fcs != ZSTD_CONTENTSIZE_ERROR &&
++	    fcs != ZSTD_CONTENTSIZE_UNKNOWN && fcs > dlen) {
++		if (fcs > SIZE_MAX)
++			return -1;
++		tmp = malloc(fcs);
++		if (!tmp)
++			return -1;
++		out_buf = tmp;
++		out_len = fcs;
++	}
++
++	wsize = zstd_dctx_workspace_bound();
++	workspace = malloc(wsize);
++	if (!workspace) {
++		free(tmp);
++		return -1;
++	}
++
++	ctx = zstd_init_dctx(workspace, wsize);
++	if (!ctx) {
++		free(workspace);
++		free(tmp);
++		return -1;
++	}
++
++	ret = zstd_decompress_dctx(ctx, out_buf, out_len, cbuf, clen);
++	free(workspace);
++
++	if (zstd_is_error(ret) || ret < dlen) {
++		free(tmp);
++		return -1;
++	}
++
++	if (tmp) {
++		memcpy(dbuf, tmp, dlen);
++		free(tmp);
++	}
++
++	return dlen;
+ }
+
+ u32 btrfs_decompress(u8 type, const char *c, u32 clen, char *d, u32 dlen)

--- a/patch/u-boot/v2026.07/general-fix-btrfs-zstd-decompression.patch
+++ b/patch/u-boot/v2026.07/general-fix-btrfs-zstd-decompression.patch
@@ -4,7 +4,7 @@ Date: Thu, 10 Apr 2026 00:00:00 +0000
 Subject: [PATCH] fs: btrfs: fix zstd decompression for BTRFS extents
 
 The generic zstd_decompress() wrapper in lib/zstd/zstd.c works for FIT
-images but fails for BTRFS filesystem extents due to two issues:
+images but fails for BTRFS filesystem extents due to three issues:
 
 1. Sector-aligned compressed size: BTRFS stores compressed extents
    padded to sector boundaries (4096 bytes).  The on-disk size
@@ -19,7 +19,12 @@ images but fails for BTRFS filesystem extents due to two issues:
    buffer is sized to ram_bytes, zstd_decompress_dctx() fails with
    ZSTD_error_dstSize_tooSmall (error 70) for inline extents.
 
-Both issues manifest as boot failures on zstd-compressed BTRFS:
+3. Short extents: a frame may legitimately decompress to fewer bytes
+   than the destination buffer (ram_bytes).  Treating that as an error
+   fails reads of short extents whose tail must be zero-filled.
+
+The first two issues manifest as boot failures on zstd-compressed
+BTRFS:
 
   zstd_decompress: failed to decompress: 70
   BTRFS: An error occurred while reading file /boot/boot.scr
@@ -31,18 +36,24 @@ Fix by calling zstd_decompress_dctx() directly with two adjustments:
   to more than dlen bytes, and allocate a temporary buffer for the
   full decompressed frame when needed.
 
+Return the actual number of decompressed bytes, capped at dlen so that
+sector padding beyond ram_bytes is never copied out.  A short result
+is not an error: like decompress_zlib() and decompress_lzo(), report
+the real length and let the caller's read path zero-fill the rest of
+the destination.  -1 is returned only on real failures.
+
 This is consistent with decompress_lzo() and decompress_zlib() which
 also call their library functions directly without generic wrappers.
 
 Signed-off-by: Igor Velkov <iav-armbian@draconpern.com>
 ---
- fs/btrfs/compression.c | 66 +++++++++++++++++++++++++++++++++++++++++++----
- 1 file changed, 62 insertions(+), 4 deletions(-)
+ fs/btrfs/compression.c | 76 ++++++++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 72 insertions(+), 4 deletions(-)
 
 diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
 --- a/fs/btrfs/compression.c
 +++ b/fs/btrfs/compression.c
-@@ -137,12 +137,70 @@
+@@ -137,12 +137,80 @@
 
  static u32 decompress_zstd(const u8 *cbuf, u32 clen, u8 *dbuf, u32 dlen)
  {
@@ -53,11 +64,12 @@ diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
 +	unsigned long long fcs;
 +	u8 *tmp = NULL;
 +	u8 *out_buf = dbuf;
-+
-+	out_len = dlen;
 
 -	abuf_init_set(&in, (u8 *)cbuf, clen);
 -	abuf_init_set(&out, dbuf, dlen);
++	out_len = dlen;
+
+-	return zstd_decompress(&in, &out);
 +	/*
 +	 * Find the actual compressed frame size. BTRFS stores compressed
 +	 * extents padded to sector boundaries, but zstd_decompress_dctx()
@@ -66,8 +78,7 @@ diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
 +	frame_csize = zstd_find_frame_compressed_size(cbuf, clen);
 +	if (!zstd_is_error(frame_csize))
 +		clen = frame_csize;
-
--	return zstd_decompress(&in, &out);
++
 +	/*
 +	 * BTRFS compresses in sector-sized blocks, so the zstd frame may
 +	 * decompress to a full sector (e.g. 4096) even when the actual
@@ -103,17 +114,27 @@ diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
 +	ret = zstd_decompress_dctx(ctx, out_buf, out_len, cbuf, clen);
 +	free(workspace);
 +
-+	if (zstd_is_error(ret) || ret < dlen) {
++	if (zstd_is_error(ret)) {
 +		free(tmp);
 +		return -1;
 +	}
 +
++	/*
++	 * The frame may carry sector padding past ram_bytes: never copy or
++	 * report more than dlen. A short result (ret < dlen) is not an
++	 * error: as in decompress_zlib() and decompress_lzo(), return the
++	 * actual decompressed length and let the read path zero-fill the
++	 * remainder of the destination.
++	 */
++	if (ret > dlen)
++		ret = dlen;
++
 +	if (tmp) {
-+		memcpy(dbuf, tmp, dlen);
++		memcpy(dbuf, tmp, ret);
 +		free(tmp);
 +	}
 +
-+	return dlen;
++	return ret;
  }
 
  u32 btrfs_decompress(u8 type, const char *c, u32 clen, char *d, u32 dlen)


### PR DESCRIPTION
Move odroidm1 from the v2026.01 rockchip u-boot pool to v2026.07,
picking up newer u-boot (incl. rk3568 "include all addressable DRAM in
memory map" and refreshed upstream DTS).

odroidm1 rides the shared tag pool (no board_odroidm1 dir; all board
config is done via hooks in the board file). The v2026.07 pool already
carries cmd-fileenv (odroidm1 enables CONFIG_CMD_FILEENV) but lacked the
btrfs zstd-decompression fix odroidm1 needs to boot zstd-compressed
btrfs (CONFIG_CMD_BTRFS). Carry that patch forward into the v2026.07
pool; it only touches the btrfs decompress path, a no-op for pool boards
that do not read btrfs.

u-boot build: 4 patches, 4 applied, 0 problems; linux-u-boot-odroidm1-edge
2026.07 builds clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared bootloader patches affect all v2026.07 rockchip builds; BTRFS decompression and PCIe timing changes sit on the early boot path before the OS loads.
> 
> **Overview**
> **Odroid M1** moves from the **v2026.01** rockchip u-boot tag/patch pool to **v2026.07** via `BOOTBRANCH_BOARD` and `BOOTPATCHDIR` in `odroidm1.conf`, aligning it with other RK3568 boards on the shared pool and picking up newer upstream u-boot (e.g. rk3568 DRAM map and DTS refresh).
> 
> The **v2026.07** pool gains two patches applied to every board that uses that directory: **`general-fix-btrfs-zstd-decompression`** rewrites BTRFS zstd decompression in u-boot so sector-padded extents and `ram_bytes` sizing work—required for Odroid M1’s enabled `CONFIG_CMD_BTRFS` / zstd-compressed root boot. **`0001-pci-pcie_dw_rockchip-increase-PCIe-LTSSM-timeout-for-cold-boot`** raises Rockchip PCIe link-up retries from 10 to 25 (~2.5s) for cold-boot NVMe enumeration (noted for RK3588/Rock 5B; warm boot unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a202422270d83515358152b00ecced84696e3e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->