### PR TITLE
armbian-install: report bootloader write failures instead of "Done."

### DIFF
--- a/packages/bsp/common/usr/bin/armbian-install
+++ b/packages/bsp/common/usr/bin/armbian-install
@@ -25,6 +25,11 @@ trap "systemctl start docker >/dev/null 2>&1; exit" INT TERM
 
 [[ -f /usr/lib/u-boot/platform_install.sh ]] && source /usr/lib/u-boot/platform_install.sh
 
+# Some board write_uboot_platform hooks are notice-only and call the build-side
+# display_alert, which does not exist in this runtime script; provide a minimal
+# shim so those hooks print their message and return 0 instead of failing 127.
+declare -F display_alert > /dev/null || display_alert() { echo "$1${2:+ $2}"; }
+
 # ORIGINAL_SCRIPT_NAME: Must be either armbian-install or nand-sata-install
 ORIGINAL_SCRIPT_NAME=$(basename $0)
 # script configuration - derive from ORIGINAL_SCRIPT_NAME
@@ -969,6 +974,40 @@ write_uboot_to_mtd_flash()
 	fi
 }
 
+# Write the platform bootloader to a block device and confirm it worked.
+# write_uboot_platform runs 'dd' without checking its exit status; callers
+# then printed "Done." unconditionally, so a failed write (a dying eMMC
+# returning -110 on cache flush, a write-protected or wrong target) was
+# indistinguishable from success and left the bootloader silently stale.
+# Capture the output, log it, and surface a real error to the user.
+#  $1 = u-boot files directory
+#  $2 = target block device
+write_bootloader_checked()
+{
+	local dir="$1" target="$2" out rc syncout
+	out=$(write_uboot_platform "$dir" "$target" 2>&1)
+	rc=$?
+	# The platform writer's dd may only queue the write (some families omit
+	# conv=fsync); flush the target so a writeback/cache-flush failure (a failing
+	# eMMC returns -110 here) is caught rather than reported as success.
+	if [[ $rc -eq 0 ]]; then
+		syncout=$(sync "$target" 2>&1)
+		rc=$?
+		[[ -n "$syncout" ]] && out+=$'\n'"$syncout"
+	fi
+	printf '%s: write bootloader to %s (rc=%d)\n%s\n' "$(date)" "${target}" "${rc}" "${out}" >> "$logfile"
+	if [[ $rc -ne 0 ]]; then
+		dialog --backtitle "$backtitle" --title ' Bootloader update FAILED ' --colors --cr-wrap --msgbox \
+			"\Z1The bootloader update on ${target} FAILED (exit ${rc}).\Zn\n\n${out}\n\nThe write may be incomplete - the board may not boot until the bootloader is rewritten successfully. Do not assume the previous bootloader is still usable. Check 'dmesg' for I/O errors." 0 0
+	elif [[ -n "$out" ]]; then
+		# Some families' write_uboot_platform prints required manual steps
+		# (e.g. fastboot instructions) instead of writing; surface that output
+		# to the user rather than swallowing it behind "Done.".
+		echo "$out"
+	fi
+	return "$rc"
+}
+
 main()
 {
 	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -1133,14 +1172,14 @@ main()
 				;;
 			5)
 				show_warning "This script will update the bootloader on ${root_partition_device}.\n\n    Continue?"
-				write_uboot_platform "$DIR" "${root_partition_device}"
+				write_bootloader_checked "$DIR" "${root_partition_device}" || return
 				update_bootscript
 				dialog --backtitle "$backtitle" --title 'Writing bootloader' --msgbox '\n          Done.' 7 30
 				return
 				;;
 			6)
 				show_warning "This script will update the bootloader on ${BOOTPART}.\n\n    Continue?"
-				write_uboot_platform "$DIR" ${BOOTPART}
+				write_bootloader_checked "$DIR" "${BOOTPART}" || return
 				echo 'Done'
 				return
 				;;


### PR DESCRIPTION
## Problem

`armbian-install` options 5/6 (Install/Update the bootloader) call
`write_uboot_platform` and then unconditionally print `Done.`.
`write_uboot_platform` runs `dd` without checking its exit status, so when the
write fails — a failing eMMC that times out on cache flush (`mmc1: cache flush
error -110`), a write-protected card, or a wrong target — the user is still
shown `Done.` while the bootloader is left stale. On a board that then fails to
boot, the installer gave no hint the write never landed.

## Fix

Add `write_bootloader_checked()`: run the platform write, capture and log its
output, and on a non-zero `dd` exit show a failure dialog naming the target
device, the exit code and dd's output, pointing at `dmesg`. `Done.` and
`update_bootscript` now run only after a successful write. Applies to the
block-device paths (5, 6); the MTD path already had its own guarded helper.

## Test

ODROID-N2 (meson64), root on eMMC btrfs. Ran option 5 "Install/Update the
bootloader on eMMC (/dev/mmcblk1)": write succeeded (rc=0), `Done.` shown;
verified the written region is byte-identical to the packaged u-boot.bin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bootloader install behavior on live systems; failures are surfaced correctly but a bad write could still brick boot if ignored—scope is limited to installer menu options 5/6.
> 
> **Overview**
> **armbian-install** no longer treats block-device bootloader updates as successful when the underlying `dd` (or cache flush) actually failed.
> 
> A new **`write_bootloader_checked`** wrapper runs `write_uboot_platform`, **`sync`** on the target to catch deferred eMMC flush errors, logs output with exit code, and shows a failure dialog on non-zero exit. Menu options **5** and **6** use it instead of calling `write_uboot_platform` directly; **`update_bootscript`** and the **Done** message run only after a successful write.
> 
> A minimal **`display_alert`** shim is added so notice-only board `write_uboot_platform` hooks that expect the build-time helper do not exit with 127 at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cba4b1c64bcc6c589733138720c1c72dd396f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->