### PR TITLE
docker: warn when buildx is missing, and reap leftover per-build images

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -138,7 +138,8 @@ function docker_cli_prepare() {
 	[[ -z "${build_suffix}" ]] && build_suffix="${EPOCHREALTIME:-$(date +%s%N)}-$$-${RANDOM}${RANDOM}"
 	build_suffix="$(printf '%s' "${build_suffix}" | sha256sum 2> /dev/null | cut -c1-8)"
 	[[ -z "${build_suffix}" ]] && build_suffix="$(printf '%08x' "$$")" # no sha256sum: PID hex
-	declare -g DOCKER_ARMBIAN_INITIAL_IMAGE_TAG="armbian.local.only/armbian-build:${build_suffix}"
+	declare -g DOCKER_ARMBIAN_LOCAL_IMAGE_REPO="armbian.local.only/armbian-build"
+	declare -g DOCKER_ARMBIAN_INITIAL_IMAGE_TAG="${DOCKER_ARMBIAN_LOCAL_IMAGE_REPO}:${build_suffix}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:trixie"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:bookworm"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:sid"}"
@@ -846,6 +847,33 @@ function docker_cleanup_old_images() {
 			done
 		fi
 	done
+
+	# Reap leftovers of the per-build tag (see DOCKER_ARMBIAN_INITIAL_IMAGE_TAG). Every run coins its
+	# own tag, so the "keep the newest 2" rule above never sees more than one image per tag and can
+	# never reap them; 'docker image prune' ignores them too, since they are tagged, not dangling.
+	# Group by repository instead, and work on tag references rather than image IDs: a cached rebuild
+	# hangs a new tag on the image it reused, and 'docker rmi <id>' refuses an image carrying several
+	# tags, so those leftovers would survive. Age comes from LastTagTime rather than the creation
+	# date, which belongs to whatever build first produced the image and can be far older than a tag
+	# that a build in flight -- possibly another user's on a shared daemon -- has only just attached
+	# to it. LastTagTime tracks the image, not the individual tag, so re-tagging shields the older
+	# tags on that image as well; erring towards keeping them costs one image worth of disk, while
+	# the opposite error kills a running build.
+	declare stale_ref stale_tag_time stale_tag_is_zero stale_tagged_at
+	declare -i stale_tag_cutoff=$(($(date +%s) - 48 * 3600))
+	while read -r stale_ref; do
+		[[ -z "${stale_ref}" ]] && continue
+		stale_tag_time="$(docker image inspect --format '{{.Metadata.LastTagTime.IsZero}} {{.Metadata.LastTagTime.Unix}}' "${stale_ref}" 2> /dev/null || true)"
+		stale_tag_is_zero="${stale_tag_time%% *}"
+		stale_tagged_at="${stale_tag_time##* }"
+		# An unset tag time renders as the year-one zero value, which would read as ancient: leave it.
+		[[ "${stale_tag_is_zero}" != "false" ]] && continue
+		[[ ! "${stale_tagged_at}" =~ ^[0-9]+$ ]] && continue
+		if [[ ${stale_tagged_at} -lt ${stale_tag_cutoff} ]]; then
+			display_alert "Removing leftover per-build image" "${stale_ref}" "debug"
+			docker rmi "${stale_ref}" > /dev/null 2>&1 || true
+		fi
+	done < <(docker images --format '{{.Repository}}:{{.Tag}}' "${DOCKER_ARMBIAN_LOCAL_IMAGE_REPO:-"armbian.local.only/armbian-build"}" 2> /dev/null)
 
 	display_alert "Docker cleanup complete" "dangling images removed, old armbian images pruned" "info"
 }

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -467,6 +467,15 @@ function docker_cli_build_dockerfile() {
 		display_alert "Re-created" "Dockerfile, proceeding, build from scratch" "debug"
 	fi
 
+	# Without buildx, the classic builder keeps its layer cache only in the image store, so the
+	# per-build image removed at the end of every run (see docker_cli_launch) takes the cache with
+	# it: each invocation re-runs the whole Dockerfile, including the expensive requirements step.
+	# Those images also escape both reapers -- 'docker image prune' skips tagged ones, and
+	# docker_cleanup_old_images() matches a different repo -- so they pile up as well.
+	if [[ "${DOCKER_HAS_BUILDX}" != "yes" ]]; then
+		display_alert "Docker buildx not available" "install it, or this image is rebuilt from scratch on every run (and the leftovers are never cleaned up); see 'docker buildx' / package docker-buildx(-plugin)" "err"
+	fi
+
 	display_alert "Building" "Dockerfile via '${DOCKER_BUILDX_OR_BUILD[*]}'" "info"
 
 	BUILDKIT_COLORS="run=123,20,245:error=yellow:cancel=blue:warning=white" \


### PR DESCRIPTION
Two related problems on hosts without `docker buildx`, both stemming from the unique per-build image tag.

## Rebuilt from scratch on every run

`docker_cli_launch` removes the per-build image at the end of every run. With BuildKit that is harmless — the layer cache lives in the builder cache, independent of the image store. With the classic builder the cache lives *only* in the image store, so removing the image takes the cache with it, and the next run re-executes the whole Dockerfile, including the expensive `compile.sh requirements` step.

Observed on a host without buildx:

```
docker build -t armbian.local.only/armbian-build:caa8bf8c ...
Step 2/19 : RUN echo "--> CACHE MISS IN DOCKERFILE: apt update." && apt-get -y update
```

19 of 19 steps, no `---> Using cache`.

The first commit warns about this in red right before the image is built, non-fatally — the build still works without buildx, it is just slow.

```
[💥] Docker buildx not available [ install it, or this image is rebuilt from scratch on every run ... ]
[🌱] Building [ Dockerfile via 'build' ]
```

## Leftovers are never cleaned up

The same images accumulate: they are tagged, so the dangling-only `docker image prune` skips them, and `docker_cleanup_old_images()` matched `docker-armbian-build`, not the local `armbian.local.only/armbian-build` repository. A host that had been building for a few weeks:

```
armbian.local.only/armbian-build:initial     5 weeks ago   2.68GB
armbian.local.only/armbian-build:dae0d66e   12 days ago    2.89GB
armbian.local.only/armbian-build:fbf62831    2 weeks ago    2.70GB
```

Widening the existing grep would not have been enough: each run coins a unique tag, so the per-tag "keep the newest 2" rule never sees more than one image per tag. The second commit groups that repository as a whole instead.

Only images that Docker no longer counts in hours are removed, which leaves anything younger than two days alone — a fresh per-build image may belong to a build still running, possibly another user's on a shared daemon. This path only runs under the opt-in `DOCKER_PRUNE=yes`.

## Testing

Warning path exercised by hiding the plugin (`docker info` then reports no buildx) and running a build: the alert fires and the build proceeds via `'build'`. With the plugin present it stays silent and the build goes via `'buildx build'`.

Selection logic checked against a real image store: an in-flight build's image (`24 minutes ago`) is kept, day/week/month-old leftovers are selected.

```
./compile.sh uboot BOARD=rockpi-4a BRANCH=edge
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Host-side Docker ergonomics only; cleanup is opt-in via DOCKER_PRUNE and uses conservative age/tag logic to reduce risk to concurrent builds.
> 
> **Overview**
> Addresses two issues tied to **unique per-build** `armbian.local.only/armbian-build` tags when hosts lack **docker buildx** or when opt-in cleanup runs.
> 
> **buildx warning:** Before `docker build`/`buildx build`, a non-fatal error alert explains that without buildx the classic builder keeps layer cache only on the image that `docker_cli_launch` removes each run—so every invocation rebuilds the full Dockerfile (including requirements)—and that tagged leftovers are not reaped elsewhere.
> 
> **Cleanup:** Introduces `DOCKER_ARMBIAN_LOCAL_IMAGE_REPO` for the per-build image repository. In `docker_cleanup_old_images()` (only when `DOCKER_PRUNE=yes`), a new pass lists all tags in that repo and removes tag references whose `LastTagTime` is older than **48 hours**, avoiding multi-tag `rmi` pitfalls and skipping images with unset tag times so recent/in-flight builds on shared daemons are less likely to be deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a3ac19085cf36b760d9cc7260a36424d8fee060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->