### PR TITLE
kernel: add opt-in linux-image-dbg package with debug info

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -19,6 +19,17 @@ function artifact_kernel_config_dump() {
 	artifact_input_variables[KERNELPATCHDIR]="${KERNELPATCHDIR}"
 	artifact_input_variables[ARCH]="${ARCH}"
 	artifact_input_variables[EXTRAWIFI]="${EXTRAWIFI:-"yes"}"
+	artifact_input_variables[KERNEL_DBG_PACKAGE]="${KERNEL_DBG_PACKAGE:-"no"}" # dbg and non-dbg targets must not be coalesced by the artifact reducer
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		# compiler inputs split the dbg artifact version, so they must split reducer groups too
+		artifact_input_variables[KERNEL_COMPILER]="${KERNEL_COMPILER}"
+		artifact_input_variables[KERNEL_EXTRA_CFLAGS]="${KERNEL_EXTRA_CFLAGS:-""}"
+		# make-time hooks also split the dbg version (artifact_kernel_prepare_version hashes their
+		# sources); mirror that here or the reducer coalesces two hook-distinct dbg/image pairs into one
+		declare dbg_make_hooks_hash=""
+		dbg_make_hooks_hash="$(dump_extension_method_sources_functions kernel_make_config custom_kernel_make_params | sha256sum | cut -d' ' -f1)"
+		artifact_input_variables[KERNEL_DBG_MAKE_HOOKS_HASH]="${dbg_make_hooks_hash}"
+	fi
 }
 
 # This is run in a logging section.
@@ -145,6 +156,36 @@ function artifact_kernel_prepare_version() {
 		"${NAME_KERNEL}"
 		"${SRC_LOADADDR}"
 	)
+	# Hash KERNEL_DBG_PACKAGE only when enabled, giving dbg-enabled builds a cache entry
+	# distinct from regular builds (a cached tarball without the dbg deb would poison them).
+	# The linux-image/-dbg pairing keys exactness on artifact_version, so builds differing
+	# in cflags, cross-toolchain prefix or toolchain version must not share a version.
+	# The linker is hashed alongside the compiler: it decides the layout of vmlinux, so two
+	# builds sharing a compiler but not a binutils would otherwise pair a dbg package with an
+	# image whose symbol addresses came out elsewhere.
+	# Versions are resolved here directly, not via the kernel-version-toolchain extension:
+	# that extension is force-enabled in main-config, which hooks running later
+	# (post_family_config, user_config) can no longer trigger — the hash must not depend
+	# on extension-enablement timing. The extension still adds the visible version part.
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		declare dbg_compiler_bin="${KERNEL_COMPILER}gcc"
+		declare dbg_linker_bin="${KERNEL_COMPILER}ld" # CROSS_COMPILE prefix; LLVM=1 uses ld.lld instead
+		if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+			dbg_compiler_bin="clang"
+			dbg_linker_bin="ld.lld"
+		fi
+		declare dbg_compiler_version=""
+		dbg_compiler_version="$("${dbg_compiler_bin}" -dumpfullversion -dumpversion 2> /dev/null || true)"
+		declare dbg_linker_version=""
+		dbg_linker_version="$("${dbg_linker_bin}" --version 2> /dev/null | head -1 || true)"
+		vars_to_hash+=(
+			"KERNEL_DBG_PACKAGE=yes"
+			"KERNEL_COMPILER=${KERNEL_COMPILER}"
+			"KERNEL_COMPILER_VERSION=${dbg_compiler_version}"
+			"KERNEL_LINKER_VERSION=${dbg_linker_version}"
+			"KERNEL_EXTRA_CFLAGS=${KERNEL_EXTRA_CFLAGS:-""}"
+		)
+	fi
 	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
 	calculate_hash_for_variables "${vars_to_hash[@]}"
 	declare vars_config_hash="${hash_variables}"
@@ -155,6 +196,11 @@ function artifact_kernel_prepare_version() {
 		"pre_package_kernel_image" "kernel_copy_extra_sources" "pre_package_kernel_headers"
 		"kernel_extra_create_patches"
 	)
+	# dbg pairing keys exactness on artifact_version: make-time hooks can change compile
+	# flags (e.g. KERNEL_EXTRA_CFLAGS), so their sources must be part of the dbg hash.
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		extension_hooks_to_hash+=("kernel_make_config" "custom_kernel_make_params")
+	fi
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"
 	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"
@@ -252,6 +298,12 @@ function artifact_kernel_prepare_version() {
 		if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
 			artifact_map_packages+=(["linux-headers"]="linux-headers-${BRANCH}-${LINUXFAMILY}")
 		fi
+
+		# opt-in debug package: unstripped vmlinux for crash/drgn/gdb analysis of vmcores.
+		# Debian-style name: "-dbg" suffixed to the name of the package it complements.
+		if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+			artifact_map_packages+=(["linux-dbg"]="linux-image-${BRANCH}-${LINUXFAMILY}-dbg")
+		fi
 	fi
 
 	# x86, specially, does not have working dtbs...
@@ -266,6 +318,11 @@ function artifact_kernel_prepare_version() {
 	# Separate artifact name if we're in DTB-only mode, so stuff doesn't get mixed up later
 	if [[ "${KERNEL_DTB_ONLY}" == "yes" ]]; then
 		artifact_name="kernel-dtb-only-${LINUXFAMILY}-${BRANCH}"
+		# Say it out loud rather than failing: KERNEL_DBG_PACKAGE may come from the family config,
+		# and a DTB-only build has no reason to break just because it inherited the request.
+		if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+			display_alert "Ignoring KERNEL_DBG_PACKAGE=yes" "KERNEL_DTB_ONLY=yes never links vmlinux" "warn"
+		fi
 	fi
 
 	artifact_type="deb-tar" # this triggers processing of .deb files in the maps to produce a tarball

--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -110,7 +110,24 @@ function armbian_kernel_config__force_pa_va_48_bits_on_arm64() {
 # Returns:
 #   0 on successful configuration application.
 function armbian_kernel_config__600_enable_ebpf_and_btf_info() {
+	# A DTB-only build never links vmlinux, so the debug package is dropped there anyway; such a
+	# build must not gain options for it, nor fail on the conflict below.
+	declare dbg_package_effective="no"
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" && "${KERNEL_DTB_ONLY:-"no"}" != "yes" ]]; then
+		dbg_package_effective="yes"
+	fi
+
+	if [[ "${dbg_package_effective}" == "yes" ]]; then
+		opts_y+=("PROC_KCORE") # crash/drgn read /proc/kcore to inspect a running kernel, not just a dump
+	fi
 	if [[ "${KERNEL_BTF}" == "no" ]]; then # If user is explicit by passing "KERNEL_BTF=no", then actually disable all debug info.
+		# Reject the conflict instead of overriding it: the debug package exists to ship the very
+		# debug info this branch turns off. Checked here, where both values are final -- config
+		# hooks running after main-config can still set either one.
+		if [[ "${dbg_package_effective}" == "yes" ]]; then
+			exit_with_error "KERNEL_BTF=no conflicts with KERNEL_DBG_PACKAGE=yes" \
+				"KERNEL_BTF=no disables CONFIG_DEBUG_INFO, leaving vmlinux without the debug info that crash, drgn and gdb need; either set KERNEL_BTF=yes (or leave it unset for Armbian's default) or drop KERNEL_DBG_PACKAGE=yes"
+		fi
 		display_alert "Disabling eBPF and BTF info for kernel" "as requested by KERNEL_BTF=no" "info"
 		opts_y+=("DEBUG_INFO_NONE")        # Enable the "none" option
 		opts_n+=("DEBUG_INFO")             # Disables debug information

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -88,6 +88,11 @@ function prepare_kernel_packaging_debs() {
 
 		display_alert "Packaging linux-libc-dev" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
 		create_kernel_deb "linux-libc-dev-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_libc_dev "linux-libc-dev"
+
+		if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+			display_alert "Packaging linux-image-dbg" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
+			create_kernel_deb "linux-image-${BRANCH}-${LINUXFAMILY}-dbg" "${debs_target_dir}" kernel_package_callback_linux_dbg "linux-dbg"
+		fi
 	fi
 
 	return 0
@@ -270,6 +275,14 @@ function kernel_package_callback_linux_image() {
 		run_host_command_logged cp -rp "${tmp_kernel_install_dirs[INSTALL_DTBS_PATH]}" "${package_directory}/usr/lib/linux-image-${kernel_version_family}"
 	fi
 
+	# The versioned virtual "-build" provide pairs linux-image with its linux-dbg package.
+	# Reversioning rewrites only the Version: field, so the artifact_version pinned here and
+	# in the dbg package's Depends survives it, keeping the pairing exact per-build.
+	declare provides_dbg_pair=""
+	if [[ "${KERNEL_DBG_PACKAGE:-"no"}" == "yes" ]]; then
+		provides_dbg_pair=", linux-image-${BRANCH}-${LINUXFAMILY}-build (= ${artifact_version})"
+	fi
+
 	# Generate a control file
 	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
 		Package: ${package_name}
@@ -282,7 +295,7 @@ function kernel_package_callback_linux_image() {
 		Section: kernel
 		Priority: optional
 		Depends: initramfs-tools | linux-initramfs-tool
-		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules
+		Provides: linux-image, linux-image-armbian, armbian-$BRANCH, wireguard-modules${provides_dbg_pair}
 		Description: Armbian Linux $BRANCH kernel image $kernel_version_family
 		 This package contains the Linux kernel, modules and corresponding other files.
 		 ${artifact_version_reason:-"${kernel_version_family}"}
@@ -605,6 +618,58 @@ function kernel_package_callback_linux_headers() {
 			fi
 		EOT_POSTINST_FINISH
 	)
+}
+
+function kernel_package_callback_linux_dbg() {
+	display_alert "linux-dbg packaging" "${package_directory}" "debug"
+
+	[[ -f "${kernel_work_dir}/vmlinux" ]] || exit_with_error "KERNEL_DBG_PACKAGE=yes, but vmlinux not found in '${kernel_work_dir}'"
+
+	# Last line of defence, after the final .config: any hook may still have turned debug info off.
+	if ! is_enabled CONFIG_DEBUG_INFO; then
+		exit_with_error "KERNEL_DBG_PACKAGE=yes, but kernel built without CONFIG_DEBUG_INFO" "vmlinux carries no DWARF, so the package would be useless to crash, drgn and gdb; check for a kernel config hook or an interactive KERNEL_CONFIGURE=yes session turning DEBUG_INFO off"
+	fi
+
+	# The config bit only records the intent. KERNEL_EXTRA_CFLAGS or a make-params hook can pass
+	# -g0 through KCFLAGS and leave CONFIG_DEBUG_INFO=y standing over an ELF with no debug
+	# sections, so ask the ELF itself. Captured, not piped into grep: grep -q exits on the first
+	# match and the SIGPIPE would surface as a pipeline failure.
+	declare vmlinux_sections=""
+	vmlinux_sections="$(readelf -S "${kernel_work_dir}/vmlinux" 2> /dev/null || true)"
+	if [[ -z "${vmlinux_sections}" ]]; then
+		display_alert "Could not read vmlinux section headers" "readelf unavailable; skipping .debug_info verification" "wrn"
+	elif [[ "${vmlinux_sections}" != *".debug_info"* ]]; then
+		exit_with_error "KERNEL_DBG_PACKAGE=yes, but vmlinux has no .debug_info section" "CONFIG_DEBUG_INFO=y is set, so the debug sections were suppressed at compile time — check KERNEL_EXTRA_CFLAGS and any kernel_make_config/custom_kernel_make_params hook for -g0 or similar"
+	fi
+
+	if is_enabled CONFIG_DEBUG_INFO_SPLIT; then
+		exit_with_error "KERNEL_DBG_PACKAGE=yes does not support CONFIG_DEBUG_INFO_SPLIT" "DWARF lives in .dwo sidecar files that are not packaged; rebuild with CONFIG_DEBUG_INFO_SPLIT=n (distro debug kernels use non-split DWARF)"
+	fi
+
+	# /usr/lib/debug/lib/modules/<ver>/vmlinux is the standard search path of crash, drgn and gdb
+	declare vmlinux_debug_dir="${package_directory}/usr/lib/debug/lib/modules/${kernel_version_family}"
+	mkdir -p "${vmlinux_debug_dir}"
+	run_host_command_logged cp -v "${kernel_work_dir}/vmlinux" "${vmlinux_debug_dir}/vmlinux"
+
+	# Generate a control file.
+	# The versioned virtual "-build" dependency pins these debug symbols to the exact kernel
+	# build: artifact_version encodes every input hash (source SHA1, patches, .config, hooks,
+	# toolchain), and reversioning does not touch Provides/Depends, so dpkg refuses to install
+	# debug symbols for a kernel built from any other combination of inputs.
+	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
+		Version: ${artifact_version}
+		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
+		Section: debug
+		Package: ${package_name}
+		Architecture: ${ARCH}
+		Priority: optional
+		Depends: linux-image-${BRANCH}-${LINUXFAMILY}, linux-image-${BRANCH}-${LINUXFAMILY}-build (= ${artifact_version})
+		Provides: linux-image-dbg, linux-image-armbian-dbg
+		Description: Armbian Linux $BRANCH debug symbols (vmlinux) ${kernel_version_family}
+		 This package contains the unstripped vmlinux for ${kernel_version_family}.
+		 It is used by crash, drgn and gdb to analyze kdump vmcores and the live kernel.
+		 ${artifact_version_reason:-"${kernel_version_family}"}
+	CONTROL_FILE
 }
 
 function kernel_package_callback_linux_libc_dev() {

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -351,6 +351,13 @@ function do_main_configuration() {
 	# loong64 is not supported now
 	#  [ "$RELEASE" = "sid" ] && [ "$ARCH" != "loong64" ] && enable_extension "apa"
 
+	# Debug symbols package pairs with its exact kernel build; the toolchain version-part
+	# makes compiler-distinct builds distinct artifacts, so the pairing stays exact.
+	# Gated after family config: KERNEL_DBG_PACKAGE may be set at the family level.
+	if [[ "${KERNEL_DBG_PACKAGE}" == "yes" ]]; then
+		enable_extension "kernel-version-toolchain"
+	fi
+
 	## Extensions: at this point we've sourced all the config files that will be used,
 	##             and (hopefully) not yet invoked any extension methods. So this is the perfect
 	##             place to initialize the extension manager. It will create functions


### PR DESCRIPTION
## Description

Kernels built with `CONFIG_DEBUG_INFO` produce a vmlinux with full debug info, but only the stripped Image is packaged — vmlinux is discarded with the build tree, leaving nothing to analyze kdump vmcores with. Debian ships it as `linux-image-*-dbg`, Ubuntu as `-dbgsym` ddebs, Fedora as `kernel-debuginfo`.

This adds `KERNEL_DBG_PACKAGE=yes` (default `no`) producing a `linux-image-<BRANCH>-<LINUXFAMILY>-dbg` package (Debian-style `-dbg` suffix) with vmlinux at `/usr/lib/debug/lib/modules/<version>/vmlinux` — the standard search path of crash, drgn and gdb.

**Exact build pairing:** linux-image declares a versioned virtual `Provides: linux-image-<BRANCH>-<LINUXFAMILY>-build (= artifact_version)`, and the dbg package carries a versioned Depends on it. `artifact_version` encodes every build input (source SHA1, patches, .config, hooks, toolchain), and deployment reversioning rewrites only the `Version:` field — so the pairing survives reversioning and dpkg refuses to install debug symbols for a kernel built from any other inputs.

**Why a build variable and not an extension:** there is currently no hook point to add a package to the kernel artifact — `artifact_map_packages` is built after the last extension hook runs, and without an entry in that map the deb would not be part of the deb-tar artifact and thus invisible to the ORAS cache. The dbg package's siblings (dtb, headers, libc-dev) are all gated by core variables; this follows the same pattern.

**Cache correctness:** the variable is hashed into the artifact version only when enabled — dbg-enabled builds get a cache entry distinct from regular builds (a cached tarball without the dbg deb would otherwise poison them).

**Cost:** vmlinux with DWARF5 is ~0.5–1 GB unpacked (measured deb: ~520 MB for meson64-edge) — hence opt-in.

## How Has This Been Tested?

- [x] `./compile.sh kernel BOARD=odroidn2 BRANCH=edge KERNEL_DBG_PACKAGE=yes` — deb produced; vmlinux is `with debug_info, not stripped` (12 `.debug_*` sections, BuildID present)
- [x] Reversioned control verified: `Version: 26.08.0-trunk`, `Depends: linux-image-edge-meson64, linux-image-edge-meson64-build (= 7.1.4-S7a5c-...)` — the versioned pairing survives reversioning

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kernel artifact versioning, OCI/cache keys, and deb control metadata; mistakes could serve wrong debug symbols or poison cached kernel tarballs, though defaults stay off and validation is strict.
> 
> **Overview**
> Introduces **`KERNEL_DBG_PACKAGE=yes`** (default off) to produce **`linux-image-<branch>-<family>-dbg`**, placing unstripped **vmlinux** under `/usr/lib/debug/lib/modules/<version>/vmlinux` for crash, drgn, and gdb.
> 
> **Packaging and pairing:** When enabled, the build adds a **`kernel_package_callback_linux_dbg`** path, registers **`linux-dbg`** in **`artifact_map_packages`**, and ties **linux-image** to the dbg deb via versioned virtual **`Provides`/`Depends`** on **`linux-image-*-build (= artifact_version)`** so reversioned repo **`Version:`** fields do not break install-time matching.
> 
> **Artifact cache / reducer:** Dbg vs non-dbg builds stay separate in the artifact reducer and version hash (including compiler, linker, **`KERNEL_EXTRA_CFLAGS`**, and make-hook sources when dbg is on). **`kernel-version-toolchain`** is auto-enabled from **`main-config`** when dbg is requested.
> 
> **Kernel config:** Enables **`PROC_KCORE`** for effective dbg builds, errors on **`KERNEL_BTF=no`** with dbg enabled, and skips or warns when **`KERNEL_DTB_ONLY=yes`**. Packaging validates **`CONFIG_DEBUG_INFO`**, **`.debug_info`** in the ELF, and rejects **`CONFIG_DEBUG_INFO_SPLIT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05b2b2fc35756583ac20eeed97a9a49515640c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->