### PR TITLE
rockpi-4a: WIP u-boot v2024.07 + btrfs (SPI-safe fallback to the v2026.04 bump)

### DIFF
--- a/config/boards/rockpi-4a.csc
+++ b/config/boards/rockpi-4a.csc
@@ -4,12 +4,27 @@ BOARD_VENDOR="radxa"
 BOARDFAMILY="rockchip64"
 BOARD_MAINTAINER=""
 INTRODUCED="2019"
+BOOTBRANCH_BOARD="tag:v2024.07"
+BOOTPATCHDIR="v2024.07"
 BOOTCONFIG="rock-pi-4-rk3399_defconfig"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4a.dtb"
-BOOT_SCENARIO="tpl-spl-blob"
+BOOT_SCENARIO="binman-atf-mainline"
 BOOT_SUPPORT_SPI=yes
-DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.20.bin"
+enable_extension "uboot-btrfs"
+
+# v2024.07 is the last u-boot before the DT sync that raised the SPI NOR to
+# 108 MHz (v2024.10), so SPI still runs at the upstream 10 MHz and works on the
+# XT25F32 here. Its rock-pi-4 defconfig sets CONFIG_SYS_SPI_U_BOOT_OFFS=0xE0000,
+# while the generic rockchip64 rkspi_loader.img places u-boot.itb at 0x60000 —
+# SPL would never find the FIT. Ship binman's ready-made SPI image instead and
+# skip the generic SPI postprocess; family write_uboot_platform/_mtd already
+# handle u-boot-rockchip[-spi].bin.
+function post_family_config__rockpi4a_binman_spi_image() {
+	display_alert "$BOARD" "u-boot: package binman SPI image (u-boot-rockchip-spi.bin)" "info"
+	declare -g UBOOT_TARGET_MAP="BL31=bl31.elf ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess
+}

--- a/patch/u-boot/v2024.07/general-fix-btrfs-zstd-decompression.patch
+++ b/patch/u-boot/v2024.07/general-fix-btrfs-zstd-decompression.patch
@@ -1,0 +1,140 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Velkov <iav-armbian@draconpern.com>
+Date: Thu, 10 Apr 2026 00:00:00 +0000
+Subject: [PATCH] fs: btrfs: fix zstd decompression for BTRFS extents
+
+The generic zstd_decompress() wrapper in lib/zstd/zstd.c works for FIT
+images but fails for BTRFS filesystem extents due to three issues:
+
+1. Sector-aligned compressed size: BTRFS stores compressed extents
+   padded to sector boundaries (4096 bytes).  The on-disk size
+   (disk_num_bytes) may be larger than the actual zstd frame.
+   zstd_decompress_dctx() rejects trailing data after the frame,
+   causing decompression failures for regular (non-inline) extents.
+
+2. Sector-aligned decompressed size: BTRFS compresses in sector-sized
+   blocks, so the zstd frame content size may exceed the actual data
+   size (ram_bytes) stored in extent metadata.  For example, a 3906
+   byte file is compressed as a 4096 byte block.  When the output
+   buffer is sized to ram_bytes, zstd_decompress_dctx() fails with
+   ZSTD_error_dstSize_tooSmall (error 70) for inline extents.
+
+3. Short extents: a frame may legitimately decompress to fewer bytes
+   than the destination buffer (ram_bytes).  Treating that as an error
+   fails reads of short extents whose tail must be zero-filled.
+
+The first two issues manifest as boot failures on zstd-compressed
+BTRFS:
+
+  zstd_decompress: failed to decompress: 70
+  BTRFS: An error occurred while reading file /boot/boot.scr
+
+Fix by calling zstd_decompress_dctx() directly with two adjustments:
+- Use zstd_find_frame_compressed_size() to strip sector padding from
+  the input, giving zstd the exact frame size.
+- Use ZSTD_getFrameContentSize() to detect when the frame decompresses
+  to more than dlen bytes, and allocate a temporary buffer for the
+  full decompressed frame when needed.
+
+Return the actual number of decompressed bytes, capped at dlen so that
+sector padding beyond ram_bytes is never copied out.  A short result
+is not an error: like decompress_zlib() and decompress_lzo(), report
+the real length and let the caller's read path zero-fill the rest of
+the destination.  -1 is returned only on real failures.
+
+This is consistent with decompress_lzo() and decompress_zlib() which
+also call their library functions directly without generic wrappers.
+
+Signed-off-by: Igor Velkov <iav-armbian@draconpern.com>
+---
+ fs/btrfs/compression.c | 76 ++++++++++++++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 72 insertions(+), 4 deletions(-)
+
+diff --git a/fs/btrfs/compression.c b/fs/btrfs/compression.c
+--- a/fs/btrfs/compression.c
++++ b/fs/btrfs/compression.c
+@@ -137,12 +137,80 @@
+
+ static u32 decompress_zstd(const u8 *cbuf, u32 clen, u8 *dbuf, u32 dlen)
+ {
+-	struct abuf in, out;
++	zstd_dctx *ctx;
++	size_t wsize, ret, frame_csize, out_len;
++	void *workspace;
++	unsigned long long fcs;
++	u8 *tmp = NULL;
++	u8 *out_buf = dbuf;
+
+-	abuf_init_set(&in, (u8 *)cbuf, clen);
+-	abuf_init_set(&out, dbuf, dlen);
++	out_len = dlen;
+
+-	return zstd_decompress(&in, &out);
++	/*
++	 * Find the actual compressed frame size. BTRFS stores compressed
++	 * extents padded to sector boundaries, but zstd_decompress_dctx()
++	 * requires the exact frame size without trailing padding.
++	 */
++	frame_csize = zstd_find_frame_compressed_size(cbuf, clen);
++	if (!zstd_is_error(frame_csize))
++		clen = frame_csize;
++
++	/*
++	 * BTRFS compresses in sector-sized blocks, so the zstd frame may
++	 * decompress to a full sector (e.g. 4096) even when the actual
++	 * data (ram_bytes) is smaller. Allocate a larger buffer when needed
++	 * to avoid ZSTD_error_dstSize_tooSmall.
++	 */
++	fcs = ZSTD_getFrameContentSize(cbuf, clen);
++	if (fcs != ZSTD_CONTENTSIZE_ERROR &&
++	    fcs != ZSTD_CONTENTSIZE_UNKNOWN && fcs > dlen) {
++		if (fcs > SIZE_MAX)
++			return -1;
++		tmp = malloc(fcs);
++		if (!tmp)
++			return -1;
++		out_buf = tmp;
++		out_len = fcs;
++	}
++
++	wsize = zstd_dctx_workspace_bound();
++	workspace = malloc(wsize);
++	if (!workspace) {
++		free(tmp);
++		return -1;
++	}
++
++	ctx = zstd_init_dctx(workspace, wsize);
++	if (!ctx) {
++		free(workspace);
++		free(tmp);
++		return -1;
++	}
++
++	ret = zstd_decompress_dctx(ctx, out_buf, out_len, cbuf, clen);
++	free(workspace);
++
++	if (zstd_is_error(ret)) {
++		free(tmp);
++		return -1;
++	}
++
++	/*
++	 * The frame may carry sector padding past ram_bytes: never copy or
++	 * report more than dlen. A short result (ret < dlen) is not an
++	 * error: as in decompress_zlib() and decompress_lzo(), return the
++	 * actual decompressed length and let the read path zero-fill the
++	 * remainder of the destination.
++	 */
++	if (ret > dlen)
++		ret = dlen;
++
++	if (tmp) {
++		memcpy(dbuf, tmp, ret);
++		free(tmp);
++	}
++
++	return ret;
+ }
+
+ u32 btrfs_decompress(u8 type, const char *c, u32 clen, char *d, u32 dlen)


### PR DESCRIPTION
## Why
Bumping rock-pi-4a to u-boot v2026.04 (branch `test/rockpi-4a-uboot-2026.04`) fixes btrfs but regresses SPI: the upstream DT sets the SPI NOR to 108 MHz, which the board's XT25F32 chip can't sustain. This branch is a fallback: **v2024.07** is the last release before the DT sync that raised the frequency to 108 MHz (that landed in v2024.10). Its upstream DT keeps SPI at 10 MHz and works, and `scripts/config` already exists, so btrfs is enabled via the same `uboot-btrfs` extension both Helios boards use.

## Hardware-verified (ROCK Pi 4A)
- `sf probe` → `SF: Detected xt25f32` — SPI works at 10 MHz, no regression;
- `btrsubvol` lists the subvolumes — btrfs metadata reads fine;
- the zstd-compressed kernel (46 MiB) reads and decompresses correctly (the ported `general-fix-btrfs-zstd-decompression.patch` works).

## Unsolved — asking for a fresh look
Boot doesn't complete: `uInitrd` (53 MiB) fails `Verifying Checksum ... Bad Data CRC`, `Boot failed (err=-14)`. Notably:
- two consecutive reads of uInitrd are byte-identical across the whole file — the btrfs read is stable, but the data deterministically fails its embedded checksum;
- the same initrd boots fine on v2026.04;
- the kernel (which has no embedded CRC) reads visually fine.

Prime suspect: the `v2024.07` patch directory carries the mainline `general-btrfs-fix-out-of-bounds-write.patch`, absent from `v2026.04`. Review question: could it be corrupting reads of large files, and does it interact correctly with the ported zstd-decompression patch in the `fs/btrfs` read path?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes early boot firmware, SPI flash layout, and BTRFS decompression in U-Boot—security- and boot-critical paths with known incomplete boot (uInitrd CRC) per PR notes.
> 
> **Overview**
> **Rock Pi 4A** is retargeted from the generic `tpl-spl-blob` flow to **U-Boot v2024.07** with **`binman-atf-mainline`**, **`uboot-btrfs`**, and a board hook that builds **`u-boot-rockchip-spi.bin`** via binman instead of the rockchip64 SPI postprocess (avoids SPL/FIT offset mismatch at 10 MHz SPI NOR).
> 
> A new **`patch/u-boot/v2024.07/general-fix-btrfs-zstd-decompression.patch`** replaces the generic `zstd_decompress()` wrapper in **`decompress_zstd()`** with direct `zstd_decompress_dctx()` handling: sector-padded compressed extents, oversized decompressed frames vs `ram_bytes`, and short extents with zero-fill semantics—intended to fix BTRFS boot reads (e.g. `boot.scr`) on zstd-compressed roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f1b68c009f4874b96f5093f6cf987afc5f7a13f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->