### PR TITLE
fix(patching): render patch summary at the reader's real terminal width

### DIFF
--- a/lib/functions/cli/entrypoint.sh
+++ b/lib/functions/cli/entrypoint.sh
@@ -19,6 +19,14 @@ function cli_entrypoint() {
 		trap 'echo "${FUNCNAME[*]}|${BASH_LINENO[*]}|${BASH_SOURCE[*]}|${LINENO}" >> ${SRC}/output/call-traces/calls.txt ;' RETURN
 	fi
 
+	# Capture the real terminal width once, here, before any logging redirects
+	# fd 1, so the patch-summary tables can match the user's terminal. Empty when
+	# stdout is not a tty (piped / CI), so those runs fall back to a fixed width.
+	declare -g -x ARMBIAN_TTY_COLUMNS="" # "exported" to shutup shellcheck; read by the patching wrappers
+	if [[ -t 1 ]]; then
+		ARMBIAN_TTY_COLUMNS="$(tput cols 2> /dev/null || echo "")"
+	fi
+
 	# @TODO: allow for a super-early userpatches/config-000.custom.conf.sh to be loaded, before anything else.
 	# This would allow for custom commands and interceptors.
 

--- a/lib/functions/compilation/kernel-patching.sh
+++ b/lib/functions/compilation/kernel-patching.sh
@@ -31,7 +31,10 @@ function kernel_main_patching_python() {
 		#"BOARD="                                             # BOARD is needed for the patchset selection logic; mostly for u-boot. empty for kernel.
 		#"TARGET="                                            # TARGET is need for u-boot's SPI/SATA etc selection logic. empty for kernel
 		# For table generation to fit into the screen, or being large when in GHA.
-		"COLUMNS=${COLUMNS:-160}"
+		# Prefer an explicit COLUMNS, else the terminal width captured at startup
+		# (ARMBIAN_TTY_COLUMNS); empty on piped/CI runs so patching.py picks a
+		# fixed wide width for logs instead of a synthetic narrow one.
+		"COLUMNS=${COLUMNS:-${ARMBIAN_TTY_COLUMNS:-}}"
 		"COLORFGBG=${COLORFGBG}"
 		"GITHUB_ACTIONS=${GITHUB_ACTIONS}"
 		# Needed so git can find the global .gitconfig, and Python can parse the PATH to determine which git to use.

--- a/lib/functions/compilation/uboot-patching.sh
+++ b/lib/functions/compilation/uboot-patching.sh
@@ -26,7 +26,10 @@ function uboot_main_patching_python() {
 		"TARGET=${target_patchdir}"                           # TARGET is need for u-boot's SPI/SATA etc selection logic
 		"USERPATCHES_PATH=${USERPATCHES_PATH}"                # Needed to find the userpatches.
 		# For table generation to fit into the screen, or being large when in GHA.
-		"COLUMNS=${COLUMNS:-160}"
+		# Prefer an explicit COLUMNS, else the terminal width captured at startup
+		# (ARMBIAN_TTY_COLUMNS); empty on piped/CI runs so patching.py picks a
+		# fixed wide width for logs instead of a synthetic narrow one.
+		"COLUMNS=${COLUMNS:-${ARMBIAN_TTY_COLUMNS:-}}"
 		"COLORFGBG=${COLORFGBG}"
 		"GITHUB_ACTIONS=${GITHUB_ACTIONS}"
 		# Needed so git can find the global .gitconfig, and Python can parse the PATH to determine which git to use.

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -519,10 +519,12 @@ function docker_cli_prepare_launch() {
 		# Change the ccache directory to the named volume or bind created. @TODO: this needs more love. it works for Docker, but not sudo
 		"--env" "CCACHE_DIR=${DOCKER_ARMBIAN_TARGET_PATH}/cache/ccache"
 
-		# Pass down the TERM, COLORFGBG, and the COLUMNS
+		# Pass down the TERM, COLORFGBG, and the COLUMNS. docker run has no --tty,
+		# so the container can't measure the terminal itself; forward the width
+		# captured on the host (ARMBIAN_TTY_COLUMNS) so patch tables match it.
 		"--env" "TERM=${TERM}"
 		"--env" "COLORFGBG=${COLORFGBG-}"
-		"--env" "COLUMNS=${COLUMNS:-"160"}"
+		"--env" "COLUMNS=${COLUMNS:-${ARMBIAN_TTY_COLUMNS:-}}"
 
 		# Pass down the CI env var (GitHub Actions, Jenkins, etc)
 		"--env" "CI=${CI}"                         # All CI's, hopefully

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -9,6 +9,8 @@
 #
 import logging
 import os
+import shutil
+import sys
 
 import rich.box
 # Let's use GitPython to query and manipulate the git repo
@@ -443,16 +445,33 @@ from rich.console import Console
 from rich.table import Table
 from rich.syntax import Syntax
 
-# console width is COLUMNS env var minus 12, or just 160 if GITHUB_ACTIONS env is not empty
-console_width = (int(os.environ.get("COLUMNS", 160)) - 12) if os.environ.get("GITHUB_ACTIONS", "") == "" else 160
+CONSOLE_FALLBACK_WIDTH = 160   # no terminal to measure (CI logs, piped output)
+CONSOLE_WIDTH_MARGIN = 12      # columns reserved for table borders and cell padding
+CONSOLE_MIN_WIDTH = 40         # floor so very narrow terminals still render a table
+
+# Match the table to the width the reader actually has, so a wide and a narrow
+# terminal render the same patch set the same way (just taller/shorter):
+#  - GITHUB_ACTIONS: fixed width, CI logs have no real terminal.
+#  - a real terminal (or an explicit COLUMNS): use its width; get_terminal_size
+#    honours COLUMNS first, then queries the tty.
+#  - redirected/piped output: fixed width so logs stay legible.
+if os.environ.get("GITHUB_ACTIONS", "") != "":
+	console_width = CONSOLE_FALLBACK_WIDTH
+elif sys.stdout.isatty() or os.environ.get("COLUMNS", "").isdigit():
+	console_width = max(shutil.get_terminal_size((CONSOLE_FALLBACK_WIDTH, 25)).columns - CONSOLE_WIDTH_MARGIN, CONSOLE_MIN_WIDTH)
+else:
+	console_width = CONSOLE_FALLBACK_WIDTH
 console = Console(color_system="standard", width=console_width, highlight=False)
 
 # Use Rich to print a summary of the patches
 if True:
 	summary_table = Table(title=f"Summary of {PATCH_TYPE} patches", show_header=True, show_lines=True, box=rich.box.ROUNDED)
-	summary_table.add_column("Patch / Status", overflow="fold", min_width=25)
-	summary_table.add_column("Diffstat / files", max_width=35)
-	summary_table.add_column("Author / Subject", overflow="ellipsis", min_width=25, max_width=40)
+	# Small min_width so all three columns still fit (and fold) down to
+	# CONSOLE_MIN_WIDTH; with min_width=25 the table exceeds ~70 cols and rich
+	# crops the right columns instead of folding them.
+	summary_table.add_column("Patch / Status", overflow="fold", min_width=10)
+	summary_table.add_column("Diffstat / files", overflow="fold", max_width=35)
+	summary_table.add_column("Author / Subject", overflow="fold", min_width=10, max_width=40)
 	for one_patch in VALID_PATCHES:
 		summary_table.add_row(
 			# (one_patch.markdown_name(skip_markdown=True)),  # + " " + one_patch.markdown_problems()
@@ -485,7 +504,13 @@ if any_failed_to_apply:
 			one_patch.rich_patch_output(),
 			reject_compo
 		)
-	console.print(summary_table)
+	# Reject diagnostics need room regardless of the reader's terminal: rich's
+	# Syntax word-wrap elides long unbroken diff lines with an ellipsis when the
+	# column is narrow. Give this table at least the fallback width (so a narrow
+	# terminal still gets room), but the full adaptive width when it is wider, so
+	# a wide terminal keeps every reject line it could show before.
+	console_failed = Console(color_system="standard", width=max(console_width, CONSOLE_FALLBACK_WIDTH), highlight=False)
+	console_failed.print(summary_table)
 
 if exit_with_exception is not None:
 	raise exit_with_exception


### PR DESCRIPTION
Fixes #9734. The patch summary tables forced a console width of `(COLUMNS or 160) - 12` regardless of the real terminal, and the "Diffstat / files" and "Author / Subject" columns overflowed by truncation — on a narrow terminal the right-hand columns were silently cut, so wide and narrow terminals showed different content for the same patch set.

Detect the real width instead: fixed for `GITHUB_ACTIONS` and for redirected/piped output, otherwise `shutil.get_terminal_size` (honours `COLUMNS` first, then the tty), floored at `CONSOLE_MIN_WIDTH`. Removes the need for the `COLUMNS=$(tput cols)` workaround. Switch the truncating summary columns to `overflow="fold"` so long fields wrap instead of being cut; name the three width numbers.

Tested: rendering at width 40 and 148 — all content preserved (folds), no `…` truncation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time logging and Rich table layout only; no patch application, auth, or artifact changes.
> 
> **Overview**
> Fixes patch summary tables that used a fixed `(COLUMNS or 160) - 12` width and **truncated** narrow terminals so the same patch set looked different by screen size.
> 
> **Terminal width plumbing:** `entrypoint.sh` records `ARMBIAN_TTY_COLUMNS` via `tput cols` before logging redirects stdout. Kernel/u-boot patching and Docker no longer default `COLUMNS` to `160`; they pass explicit `COLUMNS`, then `ARMBIAN_TTY_COLUMNS`, or leave it empty for piped/CI so Python can choose a stable wide layout.
> 
> **`patching.py` rendering:** Console width is **160** on GitHub Actions or non-tty stdout; on a tty or numeric `COLUMNS` it uses `shutil.get_terminal_size` with a margin and a **40-column floor**. Summary columns use lower `min_width` and **`overflow="fold"`** instead of ellipsis truncation. Failed-patch reject tables print on a console at least **160** columns wide so diff syntax is not elided on narrow terminals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03eb49ff0a0f8ed5f5323f8a612f36c7ab3f028a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->