### PR TITLE
kernel config hash: ignore modifications the source config already declares

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -129,10 +129,15 @@ function artifact_kernel_prepare_version() {
 	call_extensions_kernel_config
 	# Reduce to last assignment per key to keep hashing stable and ignore overridden options.
 	# tac reverses order so last becomes first, then sort -uk keeps first occurrence of each key.
+	declare -a kernel_config_modifying_hashes_canonical=("${kernel_config_modifying_hashes[@]}")
+	kernel_config_canonicalize_modifications kernel_config_modifying_hashes_canonical
 	declare -a kernel_config_modifying_hashes_reduced=()
 	mapfile -t kernel_config_modifying_hashes_reduced < <(
-		printf '%s\n' "${kernel_config_modifying_hashes[@]}" | tac | LC_ALL=C sort -s -t '=' -uk 1,1
+		printf '%s\n' "${kernel_config_modifying_hashes_canonical[@]}" | tac | LC_ALL=C sort -s -t '=' -uk 1,1
 	)
+	# Setting an option to the value the config file already carries produces the same kernel;
+	# such a modification must not move the version away from the one built without it.
+	kernel_config_drop_modifications_matching_file kernel_config_modifying_hashes_reduced "${kernel_config_source_filename}"
 	kernel_config_modification_hash="$(printf '%s\n' "${kernel_config_modifying_hashes_reduced[@]}" | sha256sum | cut -d' ' -f1)"
 	kernel_config_modification_hash="${kernel_config_modification_hash:0:16}" # "long hash"
 	declare kernel_config_modification_hash_short="${kernel_config_modification_hash:0:${short_hash_size}}"

--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -131,6 +131,90 @@ function call_extensions_kernel_config() {
 	armbian_kernel_config_apply_opts_from_arrays
 }
 
+# Rewrites the array named by ${1}, spelling every announced option with the CONFIG_ prefix.
+#
+# Hooks name options either way and scripts/config accepts both, so the two spellings mean the
+# same option and must collapse to one key before the last-assignment-wins reduction: otherwise
+# a hook that overrides an earlier one under the other spelling leaves both entries in the hash.
+function kernel_config_canonicalize_modifications() {
+	declare -n announcements="${1}"
+
+	declare -a canonical=()
+	declare entry
+	for entry in "${announcements[@]}"; do
+		# Announcements without a value (free-form markers such as `mod2noconfig`) name no option.
+		if [[ "${entry}" == *"="* ]] && [[ "${entry}" != CONFIG_* ]]; then
+			entry="CONFIG_${entry}"
+		fi
+		canonical+=("${entry}")
+	done
+
+	announcements=("${canonical[@]}")
+}
+
+# Removes announced kernel config modifications that the source config already declares.
+#
+# Hooks announce every option they touch, and those announcements feed the kernel artifact
+# version. An option set to the value the source config already carries produces the very same
+# kernel, yet still moves the version, and so cuts the board off from the published kernel debs.
+#
+# Reads and rewrites the array named by ${1}; ${2} is the source config file to compare against.
+# Announcements that are not `OPTION=value` pairs (free-form markers such as `mod2noconfig`)
+# carry nothing to compare and are always kept.
+function kernel_config_drop_modifications_matching_file() {
+	declare -n modifications="${1}"
+	declare config_file="${2}"
+
+	[[ -f "${config_file}" ]] || return 0
+
+	declare -A config_file_values=()
+	declare line key value
+	# Some tracked configs end without a newline, so take what read() leaves behind at EOF.
+	while IFS="" read -r line || [[ -n "${line}" ]]; do
+		case "${line}" in
+			CONFIG_*=*)
+				key="${line%%=*}"
+				value="${line#*=}"
+				;;
+			"# CONFIG_"*" is not set")
+				key="${line#\# }"
+				key="${key%% is not set}"
+				value="n"
+				;;
+			*)
+				continue
+				;;
+		esac
+		config_file_values["${key}"]="${value}"
+	done < "${config_file}"
+
+	declare -a kept=()
+	declare -i dropped=0
+	declare entry
+	for entry in "${modifications[@]}"; do
+		if [[ "${entry}" != *"="* ]]; then
+			kept+=("${entry}")
+			continue
+		fi
+		key="${entry%%=*}"
+		value="${entry#*=}"
+		# Hooks name options with or without the CONFIG_ prefix; scripts/config accepts both.
+		[[ "${key}" != CONFIG_* ]] && key="CONFIG_${key}"
+		if [[ -v "config_file_values[${key}]" ]] && [[ "${config_file_values[${key}]}" == "${value}" ]]; then
+			display_alert "Kernel config modification already in the source config" "${entry}" "debug"
+			dropped+=1
+			continue
+		fi
+		kept+=("${entry}")
+	done
+
+	if [[ ${dropped} -gt 0 ]]; then
+		display_alert "Kernel config modifications that change nothing" "${dropped} of ${#modifications[@]} ignored for versioning" "debug"
+	fi
+
+	modifications=("${kept[@]}")
+}
+
 function kernel_config_finalize() {
 	# Now, compare the .config with the previous one, and if they are the same, restore the original date.
 	# This way we avoid unnecessary recompilation of the kernel; even if the .config contents


### PR DESCRIPTION
A hook that sets an option to the value the source config already carries produces a
byte-identical `.config`, yet still moves `artifact_version` — cutting the build off from
the published kernel debs. Compare each announced `OPTION=value` against the config text
before hashing and drop the ones that match.

Every kernel family changes version once: even with no extension in play, the core
hooks re-announce options the config file already carries — 237 of 334 announcements
dropped on odroidn2/edge. One rebuild, then versions settle.

Measured on odroidn2/edge (meson64 7.1.7) with a hook setting `IP_PNP=y`, `TUN=y`,
`NFS_FS=m` — the exact values already in `linux-meson64-edge.config`. Before: `.config hook
hash` `1c3a9337c4583b24` without the hook, `029b15474d885e57` with it. After:
`c14e03f129e87bef` in both.

Not covered: an option that ends up enabled through a Kconfig dependency rather than a
literal line. Detecting that needs `make`, which version calculation deliberately runs
without.

Staging for Codex review before the PR against `armbian/build`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every kernel artifact version is computed (repo/cache matching), but only filters redundant hash inputs and does not alter how `.config` is built at compile time.
> 
> **Overview**
> **Kernel artifact versioning** now treats hook announcements more accurately before computing the `.config hook hash` (`H` in `artifact_version`).
> 
> After extensions run, announced modifications are **canonicalized** (`CONFIG_` prefix) so last-assignment-wins reduction cannot leave duplicate keys under two spellings. Then **`OPTION=value` pairs that already match the tracked source config** (including `# CONFIG_* is not set` as `=n`) are removed from the list that gets hashed. Non-pair markers (e.g. `mod2noconfig`) are unchanged.
> 
> **Effect:** hooks that re-apply values already in `linux-*.config` no longer bump the kernel deb version or break alignment with published packages, while real config deltas still affect the hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d84431c4ed10536a661d0df5dbfffa04f6a01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->